### PR TITLE
refactor(extension): integrate controls into popup media cards

### DIFF
--- a/.changeset/refactor-popup-ui.md
+++ b/.changeset/refactor-popup-ui.md
@@ -1,0 +1,10 @@
+---
+'@thaumic-cast/extension': patch
+---
+
+Refactor popup UI to integrate controls into media cards
+
+- Move speaker selection, volume controls, and cast button into CurrentTabCard
+- Add volume controls and stop button to ActiveCastCard
+- Remove separate "Cast settings" card for cleaner UI
+- Reorder layout: Active Casts now appear above Current Tab

--- a/apps/extension/src/popup/components/ActiveCastCard.module.css
+++ b/apps/extension/src/popup/components/ActiveCastCard.module.css
@@ -1,7 +1,7 @@
 .card {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
+  flex-direction: column;
+  gap: 0.5rem;
   padding-block: 0.5rem;
   padding-inline: 0.5rem;
   background: var(--color-bg);
@@ -9,11 +9,17 @@
   border: 1px solid var(--color-border);
 }
 
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .artwork {
   position: relative;
   flex-shrink: 0;
-  width: 40px;
-  height: 40px;
+  width: 36px;
+  height: 36px;
   border-radius: 4px;
   overflow: hidden;
   background: var(--color-border);
@@ -26,9 +32,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2px;
+  padding: 1px;
   background: oklch(0% 0 0 / 60%);
-  border-radius: 3px;
+  border-radius: 2px;
   color: white;
 }
 
@@ -54,7 +60,7 @@
 }
 
 .title {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-weight: 500;
   color: var(--color-text);
   white-space: nowrap;
@@ -64,7 +70,7 @@
 }
 
 .subtitle {
-  font-size: 0.7rem;
+  font-size: 0.65rem;
   color: var(--color-text-muted);
   white-space: nowrap;
   overflow: hidden;
@@ -77,13 +83,13 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  font-size: 0.65rem;
-  color: var(--color-primary);
+  font-size: 0.6rem;
+  color: var(--color-casting);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0;
-  margin-block-start: 0.25rem;
+  margin-block-start: 0.125rem;
 }
 
 .speakerIcon {
@@ -95,8 +101,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   background: transparent;
   border: 1px solid var(--color-border);
   border-radius: 4px;
@@ -117,4 +123,70 @@
 .stopButton:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
+}
+
+/* Volume Controls */
+.volumeControl {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-block: 0.25rem;
+  padding-inline: 0.25rem;
+  background: var(--color-surface);
+  border-radius: 4px;
+}
+
+.muteButton {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 0.875rem;
+  padding: 0;
+  border-radius: 2px;
+  transition: opacity 0.2s;
+}
+
+.muteButton:hover {
+  opacity: 0.8;
+}
+
+.muteButton.muted {
+  opacity: 0.5;
+}
+
+.volumeSlider {
+  flex: 1;
+  height: 4px;
+  appearance: none;
+  background: var(--color-border);
+  border-radius: 2px;
+  outline: none;
+  cursor: pointer;
+}
+
+.volumeSlider::-webkit-slider-thumb {
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  background: var(--color-primary);
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.volumeSlider:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.volumeSlider:disabled::-webkit-slider-thumb {
+  cursor: not-allowed;
+}
+
+.volumeValue {
+  flex-shrink: 0;
+  font-size: 0.65rem;
+  color: var(--color-text-muted);
+  min-width: 2rem;
+  text-align: end;
 }

--- a/apps/extension/src/popup/components/ActiveCastCard.tsx
+++ b/apps/extension/src/popup/components/ActiveCastCard.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'preact';
 import { useTranslation } from 'react-i18next';
 import type { ActiveCast, TransportState } from '@thaumic-cast/protocol';
 import { getDisplayTitle, getDisplayImage, getDisplaySubtitle } from '@thaumic-cast/protocol';
@@ -9,20 +10,39 @@ interface ActiveCastCardProps {
   cast: ActiveCast;
   /** Transport state for the target speaker */
   transportState?: TransportState;
+  /** Current volume (0-100) */
+  volume: number;
+  /** Whether speaker is muted */
+  muted: boolean;
+  /** Callback when volume changes */
+  onVolumeChange: (volume: number) => void;
+  /** Callback when mute is toggled */
+  onMuteToggle: () => void;
   /** Callback when stop button is clicked */
   onStop: () => void;
 }
 
 /**
- * Displays an active cast session with stop button.
- * Pure presentation component - receives data, emits events.
+ * Displays an active cast session with volume controls and stop button.
  * @param props - Component props
- * @param props.cast - Active cast session data
- * @param props.transportState - Transport state for the target speaker
- * @param props.onStop - Callback when stop button is clicked
+ * @param props.cast
+ * @param props.transportState
+ * @param props.volume
+ * @param props.muted
+ * @param props.onVolumeChange
+ * @param props.onMuteToggle
+ * @param props.onStop
  * @returns The rendered ActiveCastCard component
  */
-export function ActiveCastCard({ cast, transportState, onStop }: ActiveCastCardProps) {
+export function ActiveCastCard({
+  cast,
+  transportState,
+  volume,
+  muted,
+  onVolumeChange,
+  onMuteToggle,
+  onStop,
+}: ActiveCastCardProps): JSX.Element {
   const { t } = useTranslation();
 
   const title = getDisplayTitle(cast.mediaState);
@@ -31,64 +51,88 @@ export function ActiveCastCard({ cast, transportState, onStop }: ActiveCastCardP
 
   return (
     <div className={styles.card}>
-      <div className={styles.artwork}>
-        {image ? (
-          <img src={image} alt="" className={styles.image} loading="lazy" />
-        ) : (
-          <div className={styles.placeholder} aria-hidden="true">
+      <div className={styles.header}>
+        <div className={styles.artwork}>
+          {image ? (
+            <img src={image} alt="" className={styles.image} loading="lazy" />
+          ) : (
+            <div className={styles.placeholder} aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
+              </svg>
+            </div>
+          )}
+          {transportState && (
+            <div className={styles.transportOverlay}>
+              <TransportIcon state={transportState} size={14} />
+            </div>
+          )}
+        </div>
+
+        <div className={styles.info}>
+          <p className={styles.title}>{title}</p>
+          {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
+          <p className={styles.speaker}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              width="20"
-              height="20"
+              width="10"
+              height="10"
               viewBox="0 0 24 24"
               fill="currentColor"
+              className={styles.speakerIcon}
             >
-              <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
+              <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
             </svg>
-          </div>
-        )}
-        {transportState && (
-          <div className={styles.transportOverlay}>
-            <TransportIcon state={transportState} size={18} />
-          </div>
-        )}
-      </div>
+            {cast.speakerName || cast.speakerIp}
+          </p>
+        </div>
 
-      <div className={styles.info}>
-        <p className={styles.title}>{title}</p>
-        {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
-        <p className={styles.speaker}>
+        <button
+          type="button"
+          className={styles.stopButton}
+          onClick={onStop}
+          aria-label={t('stop_cast')}
+          title={t('stop_cast')}
+        >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            width="12"
-            height="12"
+            width="14"
+            height="14"
             viewBox="0 0 24 24"
             fill="currentColor"
-            className={styles.speakerIcon}
           >
-            <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
+            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
           </svg>
-          {cast.speakerName || cast.speakerIp}
-        </p>
+        </button>
       </div>
 
-      <button
-        type="button"
-        className={styles.stopButton}
-        onClick={onStop}
-        aria-label={t('stop_cast')}
-        title={t('stop_cast')}
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="currentColor"
+      {/* Volume Controls */}
+      <div className={styles.volumeControl}>
+        <button
+          type="button"
+          className={`${styles.muteButton} ${muted ? styles.muted : ''}`}
+          onClick={onMuteToggle}
+          title={muted ? t('unmute') : t('mute')}
         >
-          <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
-        </svg>
-      </button>
+          {muted ? '🔇' : '🔊'}
+        </button>
+        <input
+          type="range"
+          min="0"
+          max="100"
+          value={volume}
+          onChange={(e) => onVolumeChange(parseInt((e.target as HTMLInputElement).value, 10))}
+          className={styles.volumeSlider}
+          disabled={muted}
+        />
+        <span className={styles.volumeValue}>{volume}%</span>
+      </div>
     </div>
   );
 }

--- a/apps/extension/src/popup/components/ActiveCastsList.module.css
+++ b/apps/extension/src/popup/components/ActiveCastsList.module.css
@@ -1,7 +1,7 @@
 .section {
-  margin-block-start: 1rem;
-  padding-block-start: 1rem;
-  border-block-start: 1px solid var(--color-border);
+  margin-block-end: 1rem;
+  padding-block-end: 1rem;
+  border-block-end: 1px solid var(--color-border);
 }
 
 .heading {

--- a/apps/extension/src/popup/components/ActiveCastsList.tsx
+++ b/apps/extension/src/popup/components/ActiveCastsList.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'preact';
 import { useTranslation } from 'react-i18next';
 import type { ActiveCast, TransportState } from '@thaumic-cast/protocol';
 import { ActiveCastCard } from './ActiveCastCard';
@@ -8,20 +9,39 @@ interface ActiveCastsListProps {
   casts: ActiveCast[];
   /** Function to get transport state for a speaker IP */
   getTransportState?: (speakerIp: string) => TransportState | undefined;
+  /** Function to get volume for a speaker IP */
+  getVolume: (speakerIp: string) => number;
+  /** Function to check if a speaker is muted */
+  isMuted: (speakerIp: string) => boolean;
+  /** Callback when volume changes for a speaker */
+  onVolumeChange: (speakerIp: string, volume: number) => void;
+  /** Callback when mute is toggled for a speaker */
+  onMuteToggle: (speakerIp: string) => void;
   /** Callback when a cast stop is requested */
   onStopCast: (tabId: number) => void;
 }
 
 /**
- * List of active cast sessions.
- * Pure container - maps data to cards.
+ * List of active cast sessions with volume controls.
  * @param props - Component props
- * @param props.casts - Array of active cast sessions
- * @param props.getTransportState - Function to get transport state by speaker IP
- * @param props.onStopCast - Callback when a cast stop is requested
+ * @param props.casts
+ * @param props.getTransportState
+ * @param props.getVolume
+ * @param props.isMuted
+ * @param props.onVolumeChange
+ * @param props.onMuteToggle
+ * @param props.onStopCast
  * @returns The rendered ActiveCastsList component or null if empty
  */
-export function ActiveCastsList({ casts, getTransportState, onStopCast }: ActiveCastsListProps) {
+export function ActiveCastsList({
+  casts,
+  getTransportState,
+  getVolume,
+  isMuted,
+  onVolumeChange,
+  onMuteToggle,
+  onStopCast,
+}: ActiveCastsListProps): JSX.Element | null {
   const { t } = useTranslation();
 
   if (casts.length === 0) return null;
@@ -35,6 +55,10 @@ export function ActiveCastsList({ casts, getTransportState, onStopCast }: Active
             <ActiveCastCard
               cast={cast}
               transportState={getTransportState?.(cast.speakerIp)}
+              volume={getVolume(cast.speakerIp)}
+              muted={isMuted(cast.speakerIp)}
+              onVolumeChange={(vol) => onVolumeChange(cast.speakerIp, vol)}
+              onMuteToggle={() => onMuteToggle(cast.speakerIp)}
               onStop={() => onStopCast(cast.tabId)}
             />
           </li>

--- a/apps/extension/src/popup/components/CurrentTabCard.module.css
+++ b/apps/extension/src/popup/components/CurrentTabCard.module.css
@@ -1,13 +1,17 @@
 .card {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
   padding-block: 0.75rem;
   padding-inline: 0.75rem;
-  background: var(--color-bg);
+  background: var(--color-surface);
   border-radius: 8px;
   border: 1px solid var(--color-border);
   margin-block-end: 1rem;
+}
+
+.mediaRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-block-end: 0.75rem;
 }
 
 .artwork {
@@ -58,4 +62,128 @@
   text-overflow: ellipsis;
   margin: 0;
   margin-block-start: 0.25rem;
+}
+
+.castingStatus {
+  font-size: 0.75rem;
+  color: var(--color-casting);
+  margin: 0;
+  margin-block-start: 0.25rem;
+  font-weight: 500;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.label {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.select {
+  width: 100%;
+  padding-block: 0.5rem;
+  padding-inline: 0.5rem;
+  border-radius: 4px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+.select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Volume Controls */
+.volumeControl {
+  padding-block: 0.5rem;
+  padding-inline: 0.5rem;
+  background: var(--color-bg);
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+}
+
+.volumeHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-block-end: 0.5rem;
+}
+
+.muteButton {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0.125rem;
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+.muteButton:hover {
+  background: var(--color-border);
+}
+
+.muteButton.muted {
+  opacity: 0.6;
+}
+
+.volumeSlider {
+  width: 100%;
+  height: 6px;
+  appearance: none;
+  background: var(--color-border);
+  border-radius: 3px;
+  outline: none;
+  cursor: pointer;
+}
+
+.volumeSlider::-webkit-slider-thumb {
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  background: var(--color-primary);
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.volumeSlider:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.volumeSlider:disabled::-webkit-slider-thumb {
+  cursor: not-allowed;
+}
+
+.volumeValue {
+  display: block;
+  text-align: end;
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  margin-block-start: 0.25rem;
+}
+
+.spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/apps/extension/src/popup/components/CurrentTabCard.tsx
+++ b/apps/extension/src/popup/components/CurrentTabCard.tsx
@@ -1,46 +1,205 @@
-import type { TabMediaState } from '@thaumic-cast/protocol';
+import type { JSX } from 'preact';
+import { useTranslation } from 'react-i18next';
+import type { TabMediaState, ZoneGroup } from '@thaumic-cast/protocol';
 import { getDisplayTitle, getDisplayImage, getDisplaySubtitle } from '@thaumic-cast/protocol';
+import { Button } from '@thaumic-cast/ui';
+import { Cast, Loader2 } from 'lucide-preact';
 import styles from './CurrentTabCard.module.css';
 
 interface CurrentTabCardProps {
   /** The tab's media state */
   state: TabMediaState;
+  /** Whether this tab is already casting */
+  isCasting: boolean;
+  /** Available speaker groups */
+  groups: ZoneGroup[];
+  /** Currently selected speaker IP */
+  selectedIp: string;
+  /** Callback when speaker selection changes */
+  onSelectSpeaker: (ip: string) => void;
+  /** Callback to start casting */
+  onStartCast: () => void;
+  /** Whether cast is starting */
+  isStarting: boolean;
+  /** Whether controls are disabled (loading, no connection, etc.) */
+  disabled: boolean;
+  /** Whether speakers are loading */
+  speakersLoading: boolean;
+  /** Current volume (0-100) */
+  volume: number;
+  /** Whether speaker is muted */
+  muted: boolean;
+  /** Callback when volume changes */
+  onVolumeChange: (volume: number) => void;
+  /** Callback when mute is toggled */
+  onMuteToggle: () => void;
+  /** Whether volume controls should be shown */
+  showVolumeControls: boolean;
+  /** Function to get display name for a group */
+  getGroupDisplayName: (group: ZoneGroup) => string;
 }
 
 /**
- * Displays the current tab's media information.
- * Pure presentation component - receives data, no business logic.
+ * Displays the current tab's media information with cast controls.
  * @param props - Component props
- * @param props.state - The tab's media state
+ * @param props.state
+ * @param props.isCasting
+ * @param props.groups
+ * @param props.selectedIp
+ * @param props.onSelectSpeaker
+ * @param props.onStartCast
+ * @param props.isStarting
+ * @param props.disabled
+ * @param props.speakersLoading
+ * @param props.volume
+ * @param props.muted
+ * @param props.onVolumeChange
+ * @param props.onMuteToggle
+ * @param props.showVolumeControls
+ * @param props.getGroupDisplayName
  * @returns The rendered CurrentTabCard component
  */
-export function CurrentTabCard({ state }: CurrentTabCardProps) {
+export function CurrentTabCard({
+  state,
+  isCasting,
+  groups,
+  selectedIp,
+  onSelectSpeaker,
+  onStartCast,
+  isStarting,
+  disabled,
+  speakersLoading,
+  volume,
+  muted,
+  onVolumeChange,
+  onMuteToggle,
+  showVolumeControls,
+  getGroupDisplayName,
+}: CurrentTabCardProps): JSX.Element {
+  const { t } = useTranslation();
   const title = getDisplayTitle(state);
   const image = getDisplayImage(state);
   const subtitle = getDisplaySubtitle(state);
 
+  // Don't show controls if already casting (will show in ActiveCastCard)
+  if (isCasting) {
+    return (
+      <div className={styles.card}>
+        <div className={styles.artwork}>
+          {image ? (
+            <img src={image} alt="" className={styles.image} loading="lazy" />
+          ) : (
+            <div className={styles.placeholder} aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
+              </svg>
+            </div>
+          )}
+        </div>
+        <div className={styles.info}>
+          <p className={styles.title}>{title}</p>
+          {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
+          <p className={styles.castingStatus}>{t('casting_active')}</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={styles.card}>
-      <div className={styles.artwork}>
-        {image ? (
-          <img src={image} alt="" className={styles.image} loading="lazy" />
-        ) : (
-          <div className={styles.placeholder} aria-hidden="true">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-            >
-              <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
-            </svg>
+      <div className={styles.mediaRow}>
+        <div className={styles.artwork}>
+          {image ? (
+            <img src={image} alt="" className={styles.image} loading="lazy" />
+          ) : (
+            <div className={styles.placeholder} aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
+              </svg>
+            </div>
+          )}
+        </div>
+        <div className={styles.info}>
+          <p className={styles.title}>{title}</p>
+          {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
+        </div>
+      </div>
+
+      <div className={styles.controls}>
+        {/* Speaker Selection */}
+        <div className={styles.field}>
+          <label className={styles.label}>{t('target_speaker')}</label>
+          <select
+            value={selectedIp}
+            onChange={(e) => onSelectSpeaker((e.target as HTMLSelectElement).value)}
+            className={styles.select}
+            disabled={disabled}
+          >
+            {speakersLoading ? <option>{t('loading_speakers')}</option> : null}
+            {groups.map((g) => (
+              <option key={g.id} value={g.coordinatorIp}>
+                {getGroupDisplayName(g)}
+              </option>
+            ))}
+            {!speakersLoading && groups.length === 0 && (
+              <option value="">{t('no_speakers_found')}</option>
+            )}
+          </select>
+        </div>
+
+        {/* Volume Controls */}
+        {showVolumeControls && selectedIp && (
+          <div className={styles.volumeControl}>
+            <div className={styles.volumeHeader}>
+              <label className={styles.label}>{t('volume')}</label>
+              <button
+                type="button"
+                className={`${styles.muteButton} ${muted ? styles.muted : ''}`}
+                onClick={onMuteToggle}
+                title={muted ? t('unmute') : t('mute')}
+              >
+                {muted ? '🔇' : '🔊'}
+              </button>
+            </div>
+            <input
+              type="range"
+              min="0"
+              max="100"
+              value={volume}
+              onChange={(e) => onVolumeChange(parseInt((e.target as HTMLInputElement).value, 10))}
+              className={styles.volumeSlider}
+              disabled={muted}
+            />
+            <span className={styles.volumeValue}>{volume}%</span>
           </div>
         )}
-      </div>
-      <div className={styles.info}>
-        <p className={styles.title}>{title}</p>
-        {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
+
+        {/* Cast Button */}
+        <Button onClick={onStartCast} disabled={disabled || groups.length === 0}>
+          {isStarting ? (
+            <>
+              <Loader2 size={16} className={styles.spinner} />
+              {t('starting')}
+            </>
+          ) : (
+            <>
+              <Cast size={16} />
+              {t('start_casting')}
+            </>
+          )}
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
- Move speaker selection, volume, and cast button into CurrentTabCard
- Add volume controls and stop button to ActiveCastCard
- Remove separate "Cast settings" card for cleaner UI
- Reorder layout: Active Casts now appear above Current Tab