### PR TITLE
fix(desktop): resolve macOS "damaged app" error with ad-hoc signing

### DIFF
--- a/.changeset/fix-macos-dmg-signing.md
+++ b/.changeset/fix-macos-dmg-signing.md
@@ -1,0 +1,9 @@
+---
+'@thaumic-cast/desktop': patch
+---
+
+fix(desktop): resolve macOS "damaged app" error with ad-hoc signing
+
+- Add explicit ad-hoc signing identity for macOS builds
+- Set minimum macOS version to 12.0 (Monterey)
+- Add bundle metadata (category, copyright, publisher, description)

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -23,12 +23,20 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "category": "public.app-category.music",
+    "copyright": "© 2026 Thaumic Cast",
+    "shortDescription": "Stream browser audio to Sonos speakers",
+    "publisher": "Thaumic Cast",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
       "icons/128x128@2x.png",
       "icons/icon.ico",
       "icons/icon.png"
-    ]
+    ],
+    "macOS": {
+      "signingIdentity": "-",
+      "minimumSystemVersion": "12.0"
+    }
   }
 }


### PR DESCRIPTION
- Add explicit ad-hoc signing identity for macOS builds
- Set minimum macOS version to 12.0 (Monterey)
- Add bundle metadata (category, copyright, publisher, description)