### PR TITLE
fix(extension): update desktop download URL in onboarding

### DIFF
--- a/.changeset/fix-onboarding-download-url.md
+++ b/.changeset/fix-onboarding-download-url.md
@@ -1,0 +1,5 @@
+---
+'@thaumic-cast/extension': patch
+---
+
+Fix desktop app download URL in onboarding to point to the correct GitHub releases page.

--- a/apps/extension/src/popup/components/onboarding/DesktopConnectionStep.tsx
+++ b/apps/extension/src/popup/components/onboarding/DesktopConnectionStep.tsx
@@ -52,7 +52,7 @@ export function DesktopConnectionStep({
 
   const handleDownload = () => {
     // Open releases page in new tab
-    chrome.tabs.create({ url: 'https://github.com/thaumic-cast/releases' });
+    chrome.tabs.create({ url: 'https://github.com/brew-lab/thaumic-cast/releases/latest' });
   };
 
   /**


### PR DESCRIPTION
## What

update desktop download URL in onboarding

## Why

avoid broken urls