### PR TITLE
fix(desktop): update extension store URL in onboarding

### DIFF
--- a/.changeset/add-extension-store-url.md
+++ b/.changeset/add-extension-store-url.md
@@ -1,0 +1,5 @@
+---
+'@thaumic-cast/desktop': patch
+---
+
+Update Chrome Web Store link in onboarding to point to the published extension listing.

--- a/apps/desktop/src/components/onboarding/ExtensionStep.tsx
+++ b/apps/desktop/src/components/onboarding/ExtensionStep.tsx
@@ -37,7 +37,10 @@ export function ExtensionStep(): preact.JSX.Element {
   const handleOpenStore = () => {
     // Open Chrome Web Store in default browser
     // In Tauri, this would use shell.open
-    window.open('https://chrome.google.com/webstore', '_blank');
+    window.open(
+      'https://chromewebstore.google.com/detail/hpemmkbecklfacogdidaoncjmfadgedm',
+      '_blank',
+    );
   };
 
   return (


### PR DESCRIPTION
## What

 update extension store URL in onboarding
