### PR TITLE
fix(extension): use correct service ID in server test

### DIFF
--- a/.changeset/swift-yklya.md
+++ b/.changeset/swift-yklya.md
@@ -1,0 +1,5 @@
+---
+'@thaumic-cast/extension': patch
+---
+
+Fix service ID check to match thaumic-core constant

--- a/apps/extension/src/lib/serverTest.ts
+++ b/apps/extension/src/lib/serverTest.ts
@@ -61,7 +61,7 @@ export async function testServerConnection(
     }
 
     const data = await res.json();
-    if (data.service !== 'thaumic-cast-desktop') {
+    if (data.service !== 'thaumic-cast') {
       return { success: false, error: 'wrong_server' };
     }
 


### PR DESCRIPTION
## What

 use correct service ID in server test

## Why

so ext can connect to the the correct server

