### PR TITLE
fix(ci): pass GitHub App token to checkout for proper attribution

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -21,16 +21,17 @@ jobs:
       should-release: ${{ steps.check-tag.outputs.created }}
       version: ${{ steps.check-tag.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -48,6 +49,7 @@ jobs:
           publish: echo "skip-publish"
           title: 'chore: release packages'
           commit: 'chore: release packages'
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
Move token generation before checkout and pass the token to actions/checkout so git credentials are configured with the app identity. Also disable setupGitUser in changesets to prevent overriding the configured identity.
