### PR TITLE
feat(extension): add partial speaker removal for multi-group casts

### DIFF
--- a/.changeset/partial-speaker-removal.md
+++ b/.changeset/partial-speaker-removal.md
@@ -1,5 +1,6 @@
 ---
 '@thaumic-cast/extension': minor
+'@thaumic-cast/desktop': patch
 '@thaumic-cast/ui': minor
 '@thaumic-cast/protocol': minor
 ---
@@ -11,3 +12,4 @@ Add partial speaker removal for multi-group casts
 - Track user-initiated vs system removals for accurate analytics (user_removed reason)
 - Stop latency monitoring when a speaker is removed
 - Add translations for user_removed auto-stop reason
+- Sort speakers alphabetically for consistent UI ordering (extension and desktop)

--- a/.changeset/partial-speaker-removal.md
+++ b/.changeset/partial-speaker-removal.md
@@ -1,0 +1,13 @@
+---
+'@thaumic-cast/extension': minor
+'@thaumic-cast/ui': minor
+'@thaumic-cast/protocol': minor
+---
+
+Add partial speaker removal for multi-group casts
+
+- Add per-speaker remove button (X) to ActiveCastCard, shown only when 2+ speakers
+- Send STOP_PLAYBACK_SPEAKER command to remove individual speakers without stopping entire cast
+- Track user-initiated vs system removals for accurate analytics (user_removed reason)
+- Stop latency monitoring when a speaker is removed
+- Add translations for user_removed auto-stop reason

--- a/.changeset/partial-speaker-removal.md
+++ b/.changeset/partial-speaker-removal.md
@@ -13,3 +13,11 @@ Add partial speaker removal for multi-group casts
 - Stop latency monitoring when a speaker is removed
 - Add translations for user_removed auto-stop reason
 - Sort speakers alphabetically for consistent UI ordering (extension and desktop)
+
+UX improvements:
+
+- Add 48px touch target to volume slider for better accessibility (WCAG 2.5.5)
+- Add CSS tokens for slider dimensions, touch target size, and muted state opacity
+- Disable text selection on interactive controls (volume, speaker rows, popup header/footer)
+- Allow text selection only on track info sections (title, subtitle)
+- Use semantic CSS tokens for disabled/muted opacity states

--- a/apps/desktop/src-tauri/src/tauri_emitter.rs
+++ b/apps/desktop/src-tauri/src/tauri_emitter.rs
@@ -111,6 +111,7 @@ impl EventEmitter for TauriEventEmitter {
             StreamEvent::PlaybackStopped {
                 stream_id,
                 speaker_ip,
+                reason,
                 ..
             } => {
                 #[derive(serde::Serialize, Clone)]
@@ -118,12 +119,15 @@ impl EventEmitter for TauriEventEmitter {
                 struct PlaybackStoppedPayload {
                     stream_id: String,
                     speaker_ip: String,
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    reason: Option<thaumic_core::SpeakerRemovalReason>,
                 }
                 self.emit_to_tauri(
                     "playback-stopped",
                     PlaybackStoppedPayload {
                         stream_id: stream_id.clone(),
                         speaker_ip: speaker_ip.clone(),
+                        reason: *reason,
                     },
                 );
             }
@@ -131,6 +135,7 @@ impl EventEmitter for TauriEventEmitter {
                 stream_id,
                 speaker_ip,
                 error,
+                reason,
                 ..
             } => {
                 #[derive(serde::Serialize, Clone)]
@@ -139,6 +144,8 @@ impl EventEmitter for TauriEventEmitter {
                     stream_id: String,
                     speaker_ip: String,
                     error: String,
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    reason: Option<thaumic_core::SpeakerRemovalReason>,
                 }
                 self.emit_to_tauri(
                     "playback-stop-failed",
@@ -146,6 +153,7 @@ impl EventEmitter for TauriEventEmitter {
                         stream_id: stream_id.clone(),
                         speaker_ip: speaker_ip.clone(),
                         error: error.clone(),
+                        reason: *reason,
                     },
                 );
             }

--- a/apps/desktop/src-tauri/src/tauri_emitter.rs
+++ b/apps/desktop/src-tauri/src/tauri_emitter.rs
@@ -127,6 +127,28 @@ impl EventEmitter for TauriEventEmitter {
                     },
                 );
             }
+            StreamEvent::PlaybackStopFailed {
+                stream_id,
+                speaker_ip,
+                error,
+                ..
+            } => {
+                #[derive(serde::Serialize, Clone)]
+                #[serde(rename_all = "camelCase")]
+                struct PlaybackStopFailedPayload {
+                    stream_id: String,
+                    speaker_ip: String,
+                    error: String,
+                }
+                self.emit_to_tauri(
+                    "playback-stop-failed",
+                    PlaybackStopFailedPayload {
+                        stream_id: stream_id.clone(),
+                        speaker_ip: speaker_ip.clone(),
+                        error: error.clone(),
+                    },
+                );
+            }
         }
     }
 

--- a/apps/desktop/src/state/store.ts
+++ b/apps/desktop/src/state/store.ts
@@ -148,7 +148,8 @@ export const fetchGroups = async (): Promise<void> => {
       invoke<PlaybackSession[]>('get_playback_sessions'),
       invoke<NetworkHealth>('get_network_health'),
     ]);
-    groups.value = fetchedGroups;
+    // Sort groups alphabetically by name for consistent UI ordering
+    groups.value = [...fetchedGroups].sort((a, b) => a.name.localeCompare(b.name));
     transportStates.value = states;
     castingSpeakers.value = new Set(sessions.map((s) => s.speakerIp));
 

--- a/apps/desktop/src/views/Settings.module.css
+++ b/apps/desktop/src/views/Settings.module.css
@@ -131,7 +131,7 @@
 }
 
 .remove-button:disabled {
-  opacity: 0.5;
+  opacity: var(--button-disabled-opacity);
   cursor: not-allowed;
 }
 

--- a/apps/extension/src/background/handlers/cast.ts
+++ b/apps/extension/src/background/handlers/cast.ts
@@ -174,10 +174,11 @@ export async function handleStartCast(msg: StartCastMessage): Promise<ExtensionR
         }
       }
 
-      // Build arrays of successful speakers using domain model
+      // Build arrays of successful speakers using domain model (sorted by name for consistent UI)
       const speakerGroups = getSpeakerGroups();
-      const successfulIps = successfulResults.map((r) => r.speakerIp);
-      const successfulNames = successfulResults.map((r) => speakerGroups.getGroupName(r.speakerIp));
+      const sortedResults = speakerGroups.sortByGroupName(successfulResults, (r) => r.speakerIp);
+      const successfulIps = sortedResults.map((r) => r.speakerIp);
+      const successfulNames = sortedResults.map((r) => speakerGroups.getGroupName(r.speakerIp));
 
       // Derive source from tab URL for cache
       const source = getSourceFromUrl(tab.url);

--- a/apps/extension/src/background/handlers/cast.ts
+++ b/apps/extension/src/background/handlers/cast.ts
@@ -271,12 +271,17 @@ export async function handleRemoveSpeaker(msg: RemoveSpeakerMessage): Promise<Ex
   // The event handler will check this to set the correct removal reason
   markPendingUserRemoval(speakerIp);
 
-  const success = await offscreenBroker.stopPlaybackSpeaker(session.streamId, speakerIp);
-  if (!success) {
-    // Clear the marker since the command failed - no event will arrive
+  try {
+    const success = await offscreenBroker.stopPlaybackSpeaker(session.streamId, speakerIp);
+    if (!success) {
+      // Clear the marker since the command failed - no event will arrive
+      clearPendingUserRemoval(speakerIp);
+      return { success: false, error: 'Failed to send command' };
+    }
+    return { success: true };
+  } catch {
+    // Clear the marker on any error (e.g., offscreen doc missing)
     clearPendingUserRemoval(speakerIp);
     return { success: false, error: 'Failed to send command' };
   }
-
-  return { success: true };
 }

--- a/apps/extension/src/background/offscreen-broker.ts
+++ b/apps/extension/src/background/offscreen-broker.ts
@@ -14,6 +14,7 @@
 import type {
   EncoderConfig,
   SonosStateSnapshot,
+  SpeakerRemovalReason,
   StreamMetadata,
   SupportedCodecsResult,
 } from '@thaumic-cast/protocol';
@@ -102,13 +103,19 @@ class OffscreenBroker {
    * Stops playback on a single speaker (partial removal from multi-group cast).
    * @param streamId - The stream ID
    * @param speakerIp - The speaker IP to stop
+   * @param reason - Optional reason for stopping (propagated to server events)
    * @returns Whether the command was sent successfully
    */
-  async stopPlaybackSpeaker(streamId: string, speakerIp: string): Promise<boolean> {
+  async stopPlaybackSpeaker(
+    streamId: string,
+    speakerIp: string,
+    reason?: SpeakerRemovalReason,
+  ): Promise<boolean> {
     const response = await sendToOffscreen<{ success: boolean }>({
       type: 'STOP_PLAYBACK_SPEAKER',
       streamId,
       speakerIp,
+      reason,
     });
     return response?.success ?? false;
   }

--- a/apps/extension/src/background/offscreen-broker.ts
+++ b/apps/extension/src/background/offscreen-broker.ts
@@ -98,6 +98,21 @@ class OffscreenBroker {
     });
   }
 
+  /**
+   * Stops playback on a single speaker (partial removal from multi-group cast).
+   * @param streamId - The stream ID
+   * @param speakerIp - The speaker IP to stop
+   * @returns Whether the command was sent successfully
+   */
+  async stopPlaybackSpeaker(streamId: string, speakerIp: string): Promise<boolean> {
+    const response = await sendToOffscreen<{ success: boolean }>({
+      type: 'STOP_PLAYBACK_SPEAKER',
+      streamId,
+      speakerIp,
+    });
+    return response?.success ?? false;
+  }
+
   // ─────────────────────────────────────────────────────────────────────────────
   // WebSocket Connection
   // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/extension/src/background/routes/cast-routes.ts
+++ b/apps/extension/src/background/routes/cast-routes.ts
@@ -2,30 +2,35 @@
  * Cast Session Routes
  *
  * Handles message routing for cast session lifecycle:
- * - START_CAST, STOP_CAST, GET_CAST_STATUS, GET_ACTIVE_CASTS
+ * - START_CAST, STOP_CAST, REMOVE_SPEAKER, GET_CAST_STATUS, GET_ACTIVE_CASTS
  */
 
 import type { ActiveCastsResponse } from '../../lib/messages';
 import { registerRoute, registerValidatedRoute } from '../router';
-import { handleStartCast, handleStopCast, handleGetStatus } from '../handlers/cast';
+import {
+  handleStartCast,
+  handleStopCast,
+  handleGetStatus,
+  handleRemoveSpeaker,
+} from '../handlers/cast';
 import { getActiveCasts } from '../session-manager';
-import { StartCastMessageSchema, StopCastMessageSchema } from '../../lib/message-schemas';
+import {
+  StartCastMessageSchema,
+  StopCastMessageSchema,
+  RemoveSpeakerMessageSchema,
+} from '../../lib/message-schemas';
 
 /**
  * Registers all cast session routes.
  */
 export function registerCastRoutes(): void {
-  registerValidatedRoute('START_CAST', StartCastMessageSchema, (validated) => {
-    return new Promise((resolve) => handleStartCast(validated, resolve));
-  });
+  registerValidatedRoute('START_CAST', StartCastMessageSchema, handleStartCast);
 
-  registerValidatedRoute('STOP_CAST', StopCastMessageSchema, (validated) => {
-    return new Promise((resolve) => handleStopCast(validated, resolve));
-  });
+  registerValidatedRoute('STOP_CAST', StopCastMessageSchema, handleStopCast);
 
-  registerRoute('GET_CAST_STATUS', () => {
-    return new Promise((resolve) => handleGetStatus(resolve));
-  });
+  registerValidatedRoute('REMOVE_SPEAKER', RemoveSpeakerMessageSchema, handleRemoveSpeaker);
+
+  registerRoute('GET_CAST_STATUS', handleGetStatus);
 
   registerRoute('GET_ACTIVE_CASTS', () => {
     const response: ActiveCastsResponse = { casts: getActiveCasts() };

--- a/apps/extension/src/background/session-manager.ts
+++ b/apps/extension/src/background/session-manager.ts
@@ -73,14 +73,6 @@ interface ActiveCastSession {
 const sessions = new Map<number, ActiveCastSession>();
 
 /**
- * Tracks speakers that are being removed by user action.
- * Used to distinguish user-initiated removal from system events.
- * Entries are consumed when the corresponding PlaybackStopped event arrives,
- * or cleared immediately if the command fails.
- */
-const pendingUserRemovals = new Set<string>();
-
-/**
  * Debounced storage for session persistence, registered with manager.
  * Uses immediate persist() calls (not schedule()) since session data is critical
  * and changes are infrequent.
@@ -169,12 +161,6 @@ export function registerSession(
 export function removeSession(tabId: number): void {
   const session = sessions.get(tabId);
   if (session) {
-    // Clear any pending user removal markers for this session's speakers
-    // (prevents stale markers if session removed before PlaybackStopped events arrive)
-    for (const speakerIp of session.speakerIps) {
-      pendingUserRemovals.delete(speakerIp);
-    }
-
     sessions.delete(tabId);
 
     // Release keep-awake when no sessions remain
@@ -197,7 +183,6 @@ export function clearAllSessions(): void {
 
   log.info(`Clearing all ${sessions.size} session(s) - desktop unreachable`);
   sessions.clear();
-  pendingUserRemovals.clear();
   releaseKeepAwake();
   persistSessions();
   notifySessionsChanged();
@@ -376,43 +361,4 @@ export function onMetadataUpdate(tabId: number): void {
  */
 function persistSessions(): void {
   storage.persist();
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Pending User Removals
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Marks a speaker as being removed by user action.
- * Call this before sending the STOP_PLAYBACK_SPEAKER command.
- * @param speakerIp - The speaker IP being removed
- */
-export function markPendingUserRemoval(speakerIp: string): void {
-  pendingUserRemovals.add(speakerIp);
-  log.info(`Marked pending user removal for speaker ${speakerIp}`);
-}
-
-/**
- * Clears a pending user removal marker.
- * Call this if the STOP_PLAYBACK_SPEAKER command fails.
- * @param speakerIp - The speaker IP to clear
- */
-export function clearPendingUserRemoval(speakerIp: string): void {
-  if (pendingUserRemovals.delete(speakerIp)) {
-    log.info(`Cleared pending user removal for speaker ${speakerIp} (command failed)`);
-  }
-}
-
-/**
- * Checks and consumes a pending user removal marker.
- * Call this when handling PlaybackStopped events.
- * @param speakerIp - The speaker IP to check
- * @returns True if the removal was user-initiated, false otherwise
- */
-export function consumePendingUserRemoval(speakerIp: string): boolean {
-  const wasUserInitiated = pendingUserRemovals.delete(speakerIp);
-  if (wasUserInitiated) {
-    log.info(`Consumed pending user removal for speaker ${speakerIp}`);
-  }
-  return wasUserInitiated;
 }

--- a/apps/extension/src/domain/speaker.ts
+++ b/apps/extension/src/domain/speaker.ts
@@ -247,6 +247,19 @@ export class SpeakerGroupCollection {
   }
 
   /**
+   * Sorts items by their associated group name.
+   * Used to ensure consistent alphabetical ordering in UI.
+   * @param items - Array to sort
+   * @param getIp - Function to extract speaker IP from each item
+   * @returns Sorted copy of the array
+   */
+  sortByGroupName<T>(items: T[], getIp: (item: T) => string): T[] {
+    return [...items].sort((a, b) =>
+      this.getGroupName(getIp(a)).localeCompare(this.getGroupName(getIp(b))),
+    );
+  }
+
+  /**
    * Iterates over all groups.
    * @returns An iterator over all speaker groups
    */

--- a/apps/extension/src/lib/message-schemas.ts
+++ b/apps/extension/src/lib/message-schemas.ts
@@ -18,7 +18,12 @@ import {
   TransportStateSchema,
   PlaybackResultSchema,
   LatencyBroadcastEvent,
+  SpeakerRemovalReasonSchema,
 } from '@thaumic-cast/protocol';
+
+// Re-export SpeakerRemovalReason from protocol for convenience
+export { SpeakerRemovalReasonSchema };
+export type { SpeakerRemovalReason } from '@thaumic-cast/protocol';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Primitive Schemas
@@ -355,21 +360,6 @@ export const TransportStateUpdateMessageSchema = z.object({
 export type TransportStateUpdateMessage = z.infer<typeof TransportStateUpdateMessageSchema>;
 
 /**
- * Reasons for removing a speaker from an active cast session.
- * - `source_changed`: User switched Sonos to another source (Spotify, AirPlay, etc.)
- * - `playback_stopped`: Playback stopped on the speaker (system/network issue)
- * - `speaker_stopped`: Speaker stopped unexpectedly (e.g., stream killed due to underflow)
- * - `user_removed`: User explicitly removed the speaker via UI
- */
-export const SpeakerRemovalReasonSchema = z.enum([
-  'source_changed',
-  'playback_stopped',
-  'speaker_stopped',
-  'user_removed',
-]);
-export type SpeakerRemovalReason = z.infer<typeof SpeakerRemovalReasonSchema>;
-
-/**
  * Reasons for auto-stopping an entire cast session.
  * Includes all speaker removal reasons plus stream-level events.
  * - `stream_ended`: The stream ended on the server side
@@ -497,6 +487,8 @@ export const StopPlaybackSpeakerMessageSchema = z.object({
   type: z.literal('STOP_PLAYBACK_SPEAKER'),
   streamId: z.string(),
   speakerIp: SpeakerIpSchema,
+  /** Reason for stopping (optional for backward compat). */
+  reason: SpeakerRemovalReasonSchema.optional(),
 });
 export type StopPlaybackSpeakerMessage = z.infer<typeof StopPlaybackSpeakerMessageSchema>;
 

--- a/apps/extension/src/lib/message-schemas.ts
+++ b/apps/extension/src/lib/message-schemas.ts
@@ -82,6 +82,15 @@ export const StopCastMessageSchema = z.object({
 });
 export type StopCastMessage = z.infer<typeof StopCastMessageSchema>;
 
+export const RemoveSpeakerMessageSchema = z.object({
+  type: z.literal('REMOVE_SPEAKER'),
+  payload: z.object({
+    tabId: TabIdSchema,
+    speakerIp: SpeakerIpSchema,
+  }),
+});
+export type RemoveSpeakerMessage = z.infer<typeof RemoveSpeakerMessageSchema>;
+
 export const StartCaptureMessageSchema = z.object({
   type: z.literal('START_CAPTURE'),
   payload: z.object({
@@ -348,13 +357,15 @@ export type TransportStateUpdateMessage = z.infer<typeof TransportStateUpdateMes
 /**
  * Reasons for removing a speaker from an active cast session.
  * - `source_changed`: User switched Sonos to another source (Spotify, AirPlay, etc.)
- * - `playback_stopped`: Playback stopped on the speaker
+ * - `playback_stopped`: Playback stopped on the speaker (system/network issue)
  * - `speaker_stopped`: Speaker stopped unexpectedly (e.g., stream killed due to underflow)
+ * - `user_removed`: User explicitly removed the speaker via UI
  */
 export const SpeakerRemovalReasonSchema = z.enum([
   'source_changed',
   'playback_stopped',
   'speaker_stopped',
+  'user_removed',
 ]);
 export type SpeakerRemovalReason = z.infer<typeof SpeakerRemovalReasonSchema>;
 
@@ -362,12 +373,14 @@ export type SpeakerRemovalReason = z.infer<typeof SpeakerRemovalReasonSchema>;
  * Reasons for auto-stopping an entire cast session.
  * Includes all speaker removal reasons plus stream-level events.
  * - `stream_ended`: The stream ended on the server side
+ * - `user_removed`: User removed the last speaker via UI
  */
 export const CastAutoStopReasonSchema = z.enum([
   'source_changed',
   'playback_stopped',
   'speaker_stopped',
   'stream_ended',
+  'user_removed',
 ]);
 export type CastAutoStopReason = z.infer<typeof CastAutoStopReasonSchema>;
 
@@ -471,6 +484,13 @@ export const SetMuteMessageSchema = z.object({
   muted: z.boolean(),
 });
 export type SetMuteMessage = z.infer<typeof SetMuteMessageSchema>;
+
+export const StopPlaybackSpeakerMessageSchema = z.object({
+  type: z.literal('STOP_PLAYBACK_SPEAKER'),
+  streamId: z.string(),
+  speakerIp: SpeakerIpSchema,
+});
+export type StopPlaybackSpeakerMessage = z.infer<typeof StopPlaybackSpeakerMessageSchema>;
 
 export const ControlMediaMessageSchema = z.object({
   type: z.literal('CONTROL_MEDIA'),

--- a/apps/extension/src/lib/message-schemas.ts
+++ b/apps/extension/src/lib/message-schemas.ts
@@ -400,6 +400,14 @@ export const SpeakerRemovedMessageSchema = z.object({
 });
 export type SpeakerRemovedMessage = z.infer<typeof SpeakerRemovedMessageSchema>;
 
+export const SpeakerStopFailedMessageSchema = z.object({
+  type: z.literal('SPEAKER_STOP_FAILED'),
+  tabId: TabIdSchema,
+  speakerIp: SpeakerIpSchema,
+  error: z.string(),
+});
+export type SpeakerStopFailedMessage = z.infer<typeof SpeakerStopFailedMessageSchema>;
+
 export const WsConnectionLostMessageSchema = z.object({
   type: z.literal('WS_CONNECTION_LOST'),
   reason: z.string(),

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -119,6 +119,8 @@ export {
   type CastAutoStoppedMessage,
   SpeakerRemovedMessageSchema,
   type SpeakerRemovedMessage,
+  SpeakerStopFailedMessageSchema,
+  type SpeakerStopFailedMessage,
   WsConnectionLostMessageSchema,
   type WsConnectionLostMessage,
   NetworkHealthStatusSchema,
@@ -195,6 +197,7 @@ import type {
   ActiveCastsChangedMessage,
   CastAutoStoppedMessage,
   SpeakerRemovedMessage,
+  SpeakerStopFailedMessage,
   WsStateChangedMessage,
   VolumeUpdateMessage,
   MuteUpdateMessage,
@@ -259,6 +262,7 @@ export type BackgroundToPopupType =
   | 'ACTIVE_CASTS_CHANGED'
   | 'CAST_AUTO_STOPPED'
   | 'SPEAKER_REMOVED'
+  | 'SPEAKER_STOP_FAILED'
   | 'WS_STATE_CHANGED'
   | 'VOLUME_UPDATE'
   | 'MUTE_UPDATE'
@@ -349,6 +353,7 @@ export type BackgroundToPopupMessage =
   | ActiveCastsChangedMessage
   | CastAutoStoppedMessage
   | SpeakerRemovedMessage
+  | SpeakerStopFailedMessage
   | WsStateChangedMessage
   | VolumeUpdateMessage
   | MuteUpdateMessage

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -27,6 +27,8 @@ export {
   type StartCastMessage,
   StopCastMessageSchema,
   type StopCastMessage,
+  RemoveSpeakerMessageSchema,
+  type RemoveSpeakerMessage,
   StartCaptureMessageSchema,
   type StartCaptureMessage,
   StopCaptureMessageSchema,
@@ -139,6 +141,8 @@ export {
   type SetVolumeMessage,
   SetMuteMessageSchema,
   type SetMuteMessage,
+  StopPlaybackSpeakerMessageSchema,
+  type StopPlaybackSpeakerMessage,
   ControlMediaMessageSchema,
   type ControlMediaMessage,
   ContentControlMediaMessageSchema,
@@ -173,6 +177,7 @@ export {
 import type {
   StartCastMessage,
   StopCastMessage,
+  RemoveSpeakerMessage,
   GetSonosStateMessage,
   GetActiveCastsMessage,
   EnsureConnectionMessage,
@@ -211,6 +216,7 @@ import type {
   GetWsStatusMessage,
   SyncSonosStateMessage,
   DetectCodecsMessage,
+  StopPlaybackSpeakerMessage,
   WsConnectedMessage,
   WsDisconnectedMessage,
   WsPermanentlyDisconnectedMessage,
@@ -229,6 +235,7 @@ import type {
 export type PopupToBackgroundType =
   | 'START_CAST'
   | 'STOP_CAST'
+  | 'REMOVE_SPEAKER'
   | 'GET_CAST_STATUS'
   | 'GET_SONOS_STATE'
   | 'GET_CONNECTION_STATUS'
@@ -287,7 +294,8 @@ export type BackgroundToOffscreenType =
   | 'SYNC_SONOS_STATE'
   | 'DETECT_CODECS'
   | 'SET_VOLUME'
-  | 'SET_MUTE';
+  | 'SET_MUTE'
+  | 'STOP_PLAYBACK_SPEAKER';
 
 /** Message types: Offscreen → Background */
 export type OffscreenToBackgroundType =
@@ -314,6 +322,7 @@ export type ContentBroadcastType = 'VIDEO_SYNC_STATE_CHANGED';
 export type PopupToBackgroundMessage =
   | StartCastMessage
   | StopCastMessage
+  | RemoveSpeakerMessage
   | { type: 'GET_CAST_STATUS' }
   | GetSonosStateMessage
   | { type: 'GET_CONNECTION_STATUS' }
@@ -386,7 +395,8 @@ export type BackgroundToOffscreenMessage =
   | SyncSonosStateMessage
   | DetectCodecsMessage
   | SetVolumeMessage
-  | SetMuteMessage;
+  | SetMuteMessage
+  | StopPlaybackSpeakerMessage;
 
 /**
  * Messages sent from offscreen document to background.

--- a/apps/extension/src/locales/en.json
+++ b/apps/extension/src/locales/en.json
@@ -36,6 +36,7 @@
   "auto_stop_stream_ended": "The stream has concluded its journey",
   "auto_stop_playback_stopped": "Playback has decided to take a break",
   "auto_stop_speaker_stopped": "The speaker has wandered off mid-sentence",
+  "auto_stop_user_removed": "The last speaker was dismissed from the ritual",
 
   "loading_speakers": "Seeking speakers...",
   "no_speakers_found": "The network was searched. The speakers were not forthcoming.",
@@ -49,6 +50,7 @@
   "mute_speaker": "Mute {{name}}",
   "unmute": "Unmute",
   "unmute_speaker": "Unmute {{name}}",
+  "remove_speaker": "Remove {{name}}",
   "play": "Play",
   "pause": "Pause",
   "previous_track": "Previous track",

--- a/apps/extension/src/locales/en.json
+++ b/apps/extension/src/locales/en.json
@@ -37,6 +37,7 @@
   "auto_stop_playback_stopped": "Playback has decided to take a break",
   "auto_stop_speaker_stopped": "The speaker has wandered off mid-sentence",
   "auto_stop_user_removed": "The last speaker was dismissed from the ritual",
+  "error_speaker_stop_failed": "{{name}} declined to stop. Feel free to try again.",
 
   "loading_speakers": "Seeking speakers...",
   "no_speakers_found": "The network was searched. The speakers were not forthcoming.",

--- a/apps/extension/src/offscreen/handlers.ts
+++ b/apps/extension/src/offscreen/handlers.ts
@@ -160,7 +160,11 @@ export function setupMessageHandlers(): void {
         const validated = StopPlaybackSpeakerMessageSchema.parse(msg);
         const success = sendControlCommand({
           type: 'STOP_PLAYBACK_SPEAKER',
-          payload: { streamId: validated.streamId, ip: validated.speakerIp },
+          payload: {
+            streamId: validated.streamId,
+            ip: validated.speakerIp,
+            reason: validated.reason,
+          },
         });
         sendResponse({ success });
       } catch (err) {

--- a/apps/extension/src/popup/App.module.css
+++ b/apps/extension/src/popup/App.module.css
@@ -2,6 +2,7 @@
   inline-size: 352px;
   padding-block: 1rem;
   padding-inline: 1rem;
+  user-select: none;
 }
 
 .header {
@@ -131,7 +132,7 @@
 }
 
 .mute-button.muted {
-  opacity: 0.6;
+  opacity: var(--state-muted-opacity);
 }
 
 .volume-slider {
@@ -154,7 +155,7 @@
 }
 
 .volume-slider:disabled {
-  opacity: 0.5;
+  opacity: var(--button-disabled-opacity);
   cursor: not-allowed;
 }
 

--- a/apps/extension/src/popup/App.tsx
+++ b/apps/extension/src/popup/App.tsx
@@ -68,7 +68,7 @@ function MainPopup(): JSX.Element {
 
   // Media metadata hooks
   const { state: currentTabState } = useCurrentTabState();
-  const { casts: activeCasts, stopCast } = useActiveCasts();
+  const { casts: activeCasts, stopCast, removeSpeaker } = useActiveCasts();
 
   // Derive isCasting from activeCasts - automatically updates when sessions change
   const isCasting = currentTabState
@@ -245,6 +245,7 @@ function MainPopup(): JSX.Element {
         onMuteToggle={handleMuteToggle}
         onStopCast={stopCast}
         onControl={handleControl}
+        onRemoveSpeaker={removeSpeaker}
         showDivider={!!currentTabState && !isCasting}
         videoSyncEnabled={videoSyncEnabled}
       />

--- a/apps/extension/src/popup/App.tsx
+++ b/apps/extension/src/popup/App.tsx
@@ -6,7 +6,12 @@ import { getSpeakerAvailability } from '@thaumic-cast/protocol';
 import { Radio, Settings } from 'lucide-preact';
 import { Alert, IconButton } from '@thaumic-cast/ui';
 import styles from './App.module.css';
-import { ExtensionResponse, StartCastMessage } from '../lib/messages';
+import type {
+  ExtensionResponse,
+  StartCastMessage,
+  SpeakerStopFailedMessage,
+} from '../lib/messages';
+import { useChromeMessage } from './hooks/useChromeMessage';
 import type { SpeakerGroup } from '../domain/speaker';
 import { CurrentTabCard } from './components/CurrentTabCard';
 import { ActiveCastsList } from './components/ActiveCastsList';
@@ -110,6 +115,16 @@ function MainPopup(): JSX.Element {
       setError(autoStopMessage);
     }
   }, [autoStopNotification, autoStopMessage]);
+
+  // Handle speaker stop failure notifications
+  useChromeMessage((message) => {
+    const msg = message as { type: string };
+    if (msg.type === 'SPEAKER_STOP_FAILED') {
+      const failedMsg = message as SpeakerStopFailedMessage;
+      const name = speakerGroups.getGroupName(failedMsg.speakerIp) || failedMsg.speakerIp;
+      setError(t('error_speaker_stop_failed', { name }));
+    }
+  });
 
   /**
    * Opens the extension settings page.

--- a/apps/extension/src/popup/components/ActiveCastCard.module.css
+++ b/apps/extension/src/popup/components/ActiveCastCard.module.css
@@ -16,10 +16,12 @@
 }
 
 .card-inner {
+  --slider-touch-offset: calc((var(--touch-target-size) - var(--slider-track-height)) / 2);
+
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding-block: 0.5rem;
+  padding-block: 0.5rem var(--slider-touch-offset);
   padding-inline: 0.5rem;
 }
 
@@ -134,6 +136,7 @@
   flex: 1;
   min-inline-size: 0;
   overflow: visible;
+  user-select: text;
 }
 
 .title {

--- a/apps/extension/src/popup/components/ActiveCastCard.tsx
+++ b/apps/extension/src/popup/components/ActiveCastCard.tsx
@@ -32,6 +32,8 @@ interface ActiveCastCardProps {
   onStop: () => void;
   /** Callback when playback control is triggered */
   onControl?: (action: MediaAction) => void;
+  /** Callback when a speaker remove button is clicked */
+  onRemoveSpeaker?: (speakerIp: string) => void;
   /** Whether video sync controls should be shown (from global settings) */
   videoSyncEnabled?: boolean;
 }
@@ -47,6 +49,7 @@ interface ActiveCastCardProps {
  * @param props.onMuteToggle
  * @param props.onStop
  * @param props.onControl
+ * @param props.onRemoveSpeaker
  * @param props.videoSyncEnabled
  * @returns The rendered ActiveCastCard component
  */
@@ -59,6 +62,7 @@ export function ActiveCastCard({
   onMuteToggle,
   onStop,
   onControl,
+  onRemoveSpeaker,
   videoSyncEnabled: showVideoSync = false,
 }: ActiveCastCardProps): JSX.Element {
   const { t } = useTranslation();
@@ -257,6 +261,12 @@ export function ActiveCastCard({
                 statusIndicator={
                   transportState ? <TransportIcon state={transportState} size={10} /> : undefined
                 }
+                onRemove={
+                  cast.speakerIps.length > 1 && onRemoveSpeaker
+                    ? () => onRemoveSpeaker(ip)
+                    : undefined
+                }
+                removeLabel={t('remove_speaker', { name })}
               />
             );
           })}

--- a/apps/extension/src/popup/components/ActiveCastsList.tsx
+++ b/apps/extension/src/popup/components/ActiveCastsList.tsx
@@ -21,6 +21,8 @@ interface ActiveCastsListProps {
   onStopCast: (tabId: number) => void;
   /** Callback when playback control is triggered */
   onControl?: (tabId: number, action: MediaAction) => void;
+  /** Callback when a speaker is removed from a cast */
+  onRemoveSpeaker?: (tabId: number, speakerIp: string) => void;
   /** Whether to show bottom divider (when CurrentTabCard is visible below) */
   showDivider?: boolean;
   /** Whether video sync controls should be shown (from global settings) */
@@ -38,6 +40,7 @@ interface ActiveCastsListProps {
  * @param props.onMuteToggle
  * @param props.onStopCast
  * @param props.onControl
+ * @param props.onRemoveSpeaker
  * @param props.showDivider
  * @param props.videoSyncEnabled
  * @returns The rendered ActiveCastsList component or null if empty
@@ -51,6 +54,7 @@ export function ActiveCastsList({
   onMuteToggle,
   onStopCast,
   onControl,
+  onRemoveSpeaker,
   showDivider = false,
   videoSyncEnabled = false,
 }: ActiveCastsListProps): JSX.Element | null {
@@ -75,6 +79,9 @@ export function ActiveCastsList({
               onMuteToggle={onMuteToggle}
               onStop={() => onStopCast(cast.tabId)}
               onControl={onControl ? (action) => onControl(cast.tabId, action) : undefined}
+              onRemoveSpeaker={
+                onRemoveSpeaker ? (speakerIp) => onRemoveSpeaker(cast.tabId, speakerIp) : undefined
+              }
               videoSyncEnabled={videoSyncEnabled}
             />
           </li>

--- a/apps/extension/src/popup/components/CurrentTabCard.module.css
+++ b/apps/extension/src/popup/components/CurrentTabCard.module.css
@@ -42,6 +42,7 @@
   flex: 1;
   min-inline-size: 0;
   overflow: hidden;
+  user-select: text;
 }
 
 .title {

--- a/apps/extension/src/popup/hooks/useActiveCasts.ts
+++ b/apps/extension/src/popup/hooks/useActiveCasts.ts
@@ -14,6 +14,8 @@ interface ActiveCastsResult {
   loading: boolean;
   /** Function to stop a specific cast by tab ID */
   stopCast: (tabId: number) => Promise<void>;
+  /** Function to remove a speaker from a cast */
+  removeSpeaker: (tabId: number, speakerIp: string) => Promise<void>;
 }
 
 /**
@@ -51,5 +53,14 @@ export function useActiveCasts(): ActiveCastsResult {
     await chrome.runtime.sendMessage({ type: 'STOP_CAST', payload: { tabId } });
   }, []);
 
-  return { casts, loading, stopCast };
+  /**
+   * Removes a single speaker from a cast session.
+   * @param tabId - The tab ID of the cast
+   * @param speakerIp - The speaker IP to remove
+   */
+  const removeSpeaker = useCallback(async (tabId: number, speakerIp: string) => {
+    await chrome.runtime.sendMessage({ type: 'REMOVE_SPEAKER', payload: { tabId, speakerIp } });
+  }, []);
+
+  return { casts, loading, stopCast, removeSpeaker };
 }

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -77,6 +77,13 @@ export const StreamEventSchema = z.discriminatedUnion('type', [
     speakerIp: z.string(),
     timestamp: z.number(),
   }),
+  z.object({
+    type: z.literal('playbackStopFailed'),
+    streamId: z.string(),
+    speakerIp: z.string(),
+    error: z.string(),
+    timestamp: z.number(),
+  }),
 ]);
 export type StreamEvent = z.infer<typeof StreamEventSchema>;
 

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -3,6 +3,21 @@ import { z } from 'zod';
 import { TransportStateSchema, ZoneGroupSchema } from './sonos.js';
 
 /**
+ * Reasons for removing a speaker from an active cast session.
+ * - `source_changed`: User switched Sonos to another source (Spotify, AirPlay, etc.)
+ * - `playback_stopped`: Playback stopped on the speaker (system/network issue)
+ * - `speaker_stopped`: Speaker stopped unexpectedly (e.g., stream killed due to underflow)
+ * - `user_removed`: User explicitly removed the speaker via UI
+ */
+export const SpeakerRemovalReasonSchema = z.enum([
+  'source_changed',
+  'playback_stopped',
+  'speaker_stopped',
+  'user_removed',
+]);
+export type SpeakerRemovalReason = z.infer<typeof SpeakerRemovalReasonSchema>;
+
+/**
  * Sonos event types broadcast by desktop app.
  */
 export const SonosEventSchema = z.discriminatedUnion('type', [
@@ -75,6 +90,8 @@ export const StreamEventSchema = z.discriminatedUnion('type', [
     type: z.literal('playbackStopped'),
     streamId: z.string(),
     speakerIp: z.string(),
+    /** Reason for stopping (optional for backward compat) */
+    reason: SpeakerRemovalReasonSchema.optional(),
     timestamp: z.number(),
   }),
   z.object({
@@ -82,6 +99,8 @@ export const StreamEventSchema = z.discriminatedUnion('type', [
     streamId: z.string(),
     speakerIp: z.string(),
     error: z.string(),
+    /** Reason for the attempted stop (optional for backward compat) */
+    reason: SpeakerRemovalReasonSchema.optional(),
     timestamp: z.number(),
   }),
 ]);

--- a/packages/protocol/src/websocket.ts
+++ b/packages/protocol/src/websocket.ts
@@ -228,5 +228,12 @@ export const WsControlCommandSchema = z.discriminatedUnion('type', [
     type: z.literal('GET_MUTE'),
     payload: z.object({ ip: z.string() }),
   }),
+  z.object({
+    type: z.literal('STOP_PLAYBACK_SPEAKER'),
+    payload: z.object({
+      streamId: z.string(),
+      ip: z.string(),
+    }),
+  }),
 ]);
 export type WsControlCommand = z.infer<typeof WsControlCommandSchema>;

--- a/packages/protocol/src/websocket.ts
+++ b/packages/protocol/src/websocket.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { EncoderConfigSchema } from './encoder.js';
+import { SpeakerRemovalReasonSchema } from './events.js';
 import { InitialStatePayloadSchema } from './sonos.js';
 import { StreamMetadataSchema } from './stream.js';
 
@@ -233,6 +234,8 @@ export const WsControlCommandSchema = z.discriminatedUnion('type', [
     payload: z.object({
       streamId: z.string(),
       ip: z.string(),
+      /** Reason for stopping (optional for backward compat) */
+      reason: SpeakerRemovalReasonSchema.optional(),
     }),
   }),
 ]);

--- a/packages/thaumic-core/src/api/ws.rs
+++ b/packages/thaumic-core/src/api/ws.rs
@@ -699,16 +699,17 @@ async fn handle_ws(socket: WebSocket, state: AppState) {
                                 }
                             }
                             Ok(WsIncoming::StopPlaybackSpeaker { payload }) => {
-                                // Best-effort: stop playback and latency monitoring for speaker
-                                state
+                                // Stop playback; only stop latency monitoring if successful
+                                let stopped = state
                                     .stream_coordinator
                                     .stop_playback_speaker(&payload.stream_id, &payload.ip)
-                                    .await
-                                    .ok();
-                                state
-                                    .latency_monitor
-                                    .stop_speaker(&payload.stream_id, &payload.ip)
                                     .await;
+                                if stopped {
+                                    state
+                                        .latency_monitor
+                                        .stop_speaker(&payload.stream_id, &payload.ip)
+                                        .await;
+                                }
                             }
                             Err(_) => {} // Unknown message type, ignore
                         }

--- a/packages/thaumic-core/src/events/mod.rs
+++ b/packages/thaumic-core/src/events/mod.rs
@@ -86,6 +86,19 @@ pub enum StreamEvent {
         /// Unix timestamp in milliseconds.
         timestamp: u64,
     },
+    /// Failed to stop playback on a speaker.
+    PlaybackStopFailed {
+        /// The stream ID that failed to stop.
+        #[serde(rename = "streamId")]
+        stream_id: String,
+        /// The speaker IP address that failed to stop.
+        #[serde(rename = "speakerIp")]
+        speaker_ip: String,
+        /// Error message describing the failure.
+        error: String,
+        /// Unix timestamp in milliseconds.
+        timestamp: u64,
+    },
 }
 
 /// Network health status.

--- a/packages/thaumic-core/src/events/mod.rs
+++ b/packages/thaumic-core/src/events/mod.rs
@@ -16,7 +16,22 @@ pub use emitter::{EventEmitter, LoggingEventEmitter, NoopEventEmitter};
 // Re-export SonosEvent from sonos::gena for convenience
 pub use crate::sonos::gena::SonosEvent;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+
+/// Reasons for removing a speaker from an active cast session.
+///
+/// - `SourceChanged`: User switched Sonos to another source (Spotify, AirPlay, etc.)
+/// - `PlaybackStopped`: Playback stopped on the speaker (system/network issue)
+/// - `SpeakerStopped`: Speaker stopped unexpectedly (e.g., stream killed due to underflow)
+/// - `UserRemoved`: User explicitly removed the speaker via UI
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpeakerRemovalReason {
+    SourceChanged,
+    PlaybackStopped,
+    SpeakerStopped,
+    UserRemoved,
+}
 
 /// Events broadcast to clients.
 ///
@@ -83,6 +98,9 @@ pub enum StreamEvent {
         /// The speaker IP address that stopped playback.
         #[serde(rename = "speakerIp")]
         speaker_ip: String,
+        /// Reason for stopping (optional for backward compat).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<SpeakerRemovalReason>,
         /// Unix timestamp in milliseconds.
         timestamp: u64,
     },
@@ -96,6 +114,9 @@ pub enum StreamEvent {
         speaker_ip: String,
         /// Error message describing the failure.
         error: String,
+        /// Reason for the attempted stop (optional for backward compat).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<SpeakerRemovalReason>,
         /// Unix timestamp in milliseconds.
         timestamp: u64,
     },

--- a/packages/thaumic-core/src/lib.rs
+++ b/packages/thaumic-core/src/lib.rs
@@ -57,7 +57,8 @@ pub use context::{IpDetector, LocalIpDetector, NetworkContext, NetworkError, Url
 pub use error::{DiscoveryResult, ErrorCode, GenaResult, SoapResult, ThaumicError, ThaumicResult};
 pub use events::{
     BroadcastEvent, BroadcastEventBridge, EventEmitter, LatencyEvent, LoggingEventEmitter,
-    NetworkEvent, NetworkHealth, NoopEventEmitter, SonosEvent, StreamEvent, TopologyEvent,
+    NetworkEvent, NetworkHealth, NoopEventEmitter, SonosEvent, SpeakerRemovalReason, StreamEvent,
+    TopologyEvent,
 };
 pub use lifecycle::{Lifecycle, NoopLifecycle, ServerLifecycle};
 pub use runtime::{TaskSpawner, TokioSpawner};

--- a/packages/thaumic-core/src/services/stream_coordinator.rs
+++ b/packages/thaumic-core/src/services/stream_coordinator.rs
@@ -541,12 +541,9 @@ impl StreamCoordinator {
     /// Removes the session and broadcasts a `StreamEvent::PlaybackStopped` event.
     /// Used for partial speaker removal in multi-group scenarios.
     ///
-    /// Reserved for future use (partial speaker removal from extension).
-    ///
     /// # Arguments
     /// * `stream_id` - The stream ID
     /// * `speaker_ip` - IP address of the speaker to stop
-    #[allow(dead_code)]
     pub async fn stop_playback_speaker(
         &self,
         stream_id: &str,

--- a/packages/ui/src/Button/Button.module.css
+++ b/packages/ui/src/Button/Button.module.css
@@ -19,7 +19,7 @@
 }
 
 .btn:disabled {
-  opacity: 0.5;
+  opacity: var(--button-disabled-opacity);
   cursor: not-allowed;
   filter: grayscale(30%);
 }

--- a/packages/ui/src/IconButton/IconButton.module.css
+++ b/packages/ui/src/IconButton/IconButton.module.css
@@ -10,7 +10,7 @@
 }
 
 .icon-btn:disabled {
-  opacity: 0.5;
+  opacity: var(--button-disabled-opacity);
   cursor: not-allowed;
   filter: grayscale(30%);
 }

--- a/packages/ui/src/Speaker/SpeakerVolumeRow.module.css
+++ b/packages/ui/src/Speaker/SpeakerVolumeRow.module.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-xs);
+  user-select: none;
 }
 
 .header {
@@ -19,6 +20,7 @@
 }
 
 .remove-btn {
+  margin-inline-start: auto;
   opacity: 0;
   transition: var(--transition-opacity);
 }

--- a/packages/ui/src/Speaker/SpeakerVolumeRow.module.css
+++ b/packages/ui/src/Speaker/SpeakerVolumeRow.module.css
@@ -17,3 +17,13 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.remove-btn {
+  opacity: 0;
+  transition: var(--transition-opacity);
+}
+
+.row:hover .remove-btn,
+.row:focus-within .remove-btn {
+  opacity: 1;
+}

--- a/packages/ui/src/Speaker/SpeakerVolumeRow.tsx
+++ b/packages/ui/src/Speaker/SpeakerVolumeRow.tsx
@@ -1,4 +1,6 @@
 import type { JSX } from 'preact';
+import { X } from 'lucide-preact';
+import { IconButton } from '../IconButton';
 import { VolumeControl } from '../VolumeControl';
 import styles from './SpeakerVolumeRow.module.css';
 
@@ -23,6 +25,10 @@ interface SpeakerVolumeRowProps {
   volumeLabel: string;
   /** Optional status indicator element */
   statusIndicator?: JSX.Element;
+  /** Callback when remove button is clicked. If absent, no remove button shown. */
+  onRemove?: () => void;
+  /** Accessible label for remove button */
+  removeLabel?: string;
   /** Additional CSS class */
   className?: string;
 }
@@ -40,6 +46,8 @@ interface SpeakerVolumeRowProps {
  * @param props.unmuteLabel - Accessible label for unmute button (include speaker name)
  * @param props.volumeLabel - Accessible label for volume slider (include speaker name)
  * @param props.statusIndicator - Optional status indicator element
+ * @param props.onRemove - Optional callback when remove button is clicked
+ * @param props.removeLabel - Accessible label for remove button
  * @param props.className - Additional CSS class
  * @returns The rendered SpeakerVolumeRow component
  */
@@ -54,6 +62,8 @@ export function SpeakerVolumeRow({
   unmuteLabel,
   volumeLabel,
   statusIndicator,
+  onRemove,
+  removeLabel,
   className,
 }: SpeakerVolumeRowProps): JSX.Element {
   return (
@@ -66,6 +76,17 @@ export function SpeakerVolumeRow({
       <div className={styles.header}>
         <span className={styles.name}>{speakerName}</span>
         {statusIndicator}
+        {onRemove && (
+          <IconButton
+            size="sm"
+            className={styles.removeBtn}
+            onClick={onRemove}
+            aria-label={removeLabel}
+            title={removeLabel}
+          >
+            <X size={10} />
+          </IconButton>
+        )}
       </div>
       <VolumeControl
         volume={volume}

--- a/packages/ui/src/VolumeControl/VolumeControl.module.css
+++ b/packages/ui/src/VolumeControl/VolumeControl.module.css
@@ -6,61 +6,63 @@
   padding-inline: var(--space-xs);
   background: var(--color-surface);
   border-radius: var(--radius-sm);
+  user-select: none;
 }
 
 .mute-btn.muted {
-  opacity: 0.5;
+  opacity: var(--state-muted-opacity);
 }
 
 .slider {
   --volume: 0%;
+  --touch-offset: calc((var(--touch-target-size) - var(--slider-track-height)) / 2);
 
   flex: 1;
-  block-size: 4px;
+  block-size: var(--touch-target-size);
+  margin-block: calc(-1 * var(--touch-offset));
   appearance: none;
   background: linear-gradient(
     to right,
     var(--slider-fill) var(--volume),
     var(--slider-track) var(--volume)
   );
-  border-radius: 2px;
+  background-size: 100% var(--slider-track-height);
+  background-position: center;
+  background-repeat: no-repeat;
   outline: none;
   cursor: pointer;
 }
 
-.slider:focus-visible {
-  outline: 2px solid var(--color-focus);
-  outline-offset: 2px;
-}
-
 .slider::-webkit-slider-thumb {
   appearance: none;
-  inline-size: 12px;
-  block-size: 12px;
+  inline-size: var(--slider-thumb-size);
+  block-size: var(--slider-thumb-size);
   background: var(--slider-thumb);
   border-radius: 50%;
   cursor: pointer;
-  border: 2px solid transparent;
+  border: none;
 }
 
 .slider:focus-visible::-webkit-slider-thumb {
-  border-color: var(--color-focus);
-  box-shadow: 0 0 0 2px var(--color-bg);
+  box-shadow:
+    0 0 0 2px var(--color-bg),
+    0 0 0 4px var(--color-focus);
 }
 
 .slider::-moz-range-thumb {
   appearance: none;
-  inline-size: 12px;
-  block-size: 12px;
+  inline-size: var(--slider-thumb-size);
+  block-size: var(--slider-thumb-size);
   background: var(--slider-thumb);
   border-radius: 50%;
   cursor: pointer;
-  border: 2px solid transparent;
+  border: none;
 }
 
 .slider:focus-visible::-moz-range-thumb {
-  border-color: var(--color-focus);
-  box-shadow: 0 0 0 2px var(--color-bg);
+  box-shadow:
+    0 0 0 2px var(--color-bg),
+    0 0 0 4px var(--color-focus);
 }
 
 .value {

--- a/packages/ui/src/theme.css
+++ b/packages/ui/src/theme.css
@@ -199,6 +199,9 @@
     /* Button: Disabled */
     --button-disabled-opacity: 0.5;
 
+    /* State: Muted (audio silenced but still interactive) */
+    --state-muted-opacity: 0.5;
+
     /* Icon Button: Outline */
     --icon-button-outline-border: var(--color-border);
     --icon-button-outline-border-hover: var(--color-primary);
@@ -234,6 +237,8 @@
     --slider-track: var(--color-border);
     --slider-fill: var(--color-primary);
     --slider-thumb: var(--color-primary);
+    --slider-thumb-size: 12px;
+    --slider-track-height: 4px;
 
     /* Status indicators */
     --status-connected: var(--color-success);
@@ -307,6 +312,9 @@
     --space-md: 1rem;
     --space-lg: 1.5rem;
     --space-xl: 2rem;
+
+    /* Touch target - minimum recommended size for accessibility (WCAG 2.5.5) */
+    --touch-target-size: 48px;
 
     /* Radii */
     --radius-sm: 0.25rem;
@@ -385,6 +393,9 @@
   html {
     scroll-behavior: smooth;
     caret-color: var(--color-primary);
+
+    /* Enable smooth transitions to/from auto sizes (e.g., block-size: auto) */
+    interpolate-size: allow-keywords;
   }
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
- Add per-speaker remove button (X) to ActiveCastCard
- Send STOP_PLAYBACK_SPEAKER command via WebSocket to desktop
- Track user-initiated vs system removals for accurate analytics
- Stop latency monitoring when speaker is removed
- Clear pending removal markers on session teardown
- Refactor cast handlers to use async/await pattern
- Add Zod validation to offscreen handlers
- Make volume touch friendly