### PR TITLE
fix(extension): replace tabs permission with activeTab

### DIFF
--- a/.changeset/reduce-extension-permissions.md
+++ b/.changeset/reduce-extension-permissions.md
@@ -1,0 +1,5 @@
+---
+'@thaumic-cast/extension': patch
+---
+
+Replace `tabs` permission with `activeTab` for minimal permission footprint

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -10,7 +10,7 @@
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
   },
-  "permissions": ["tabCapture", "offscreen", "storage", "tabs", "power"],
+  "permissions": ["tabCapture", "offscreen", "storage", "activeTab", "power"],
   "host_permissions": ["http://localhost/*"],
   "background": {
     "service_worker": "src/background/main.ts",


### PR DESCRIPTION
Addresses Chrome Web Store review violation - the tabs permission was unnecessarily broad. All tab property access happens during user invocation (popup open), so activeTab is sufficient.