### PR TITLE
fix(ci): configure git identity before changesets action

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Create Release PR or Publish
         id: changesets
         uses: changesets/action@v1
@@ -78,8 +83,6 @@ jobs:
             echo "created=false" >> $GITHUB_OUTPUT
           else
             echo "Creating tag v$VERSION"
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
             git tag -a "v$VERSION" -m "Release v$VERSION"
             git push origin "v$VERSION"
             echo "created=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The changesets action needs git user.name and user.email configured when setupGitUser is false. Move the git config step earlier in the workflow so it runs before changesets creates commits.