### PR TITLE
fix(ci): sync server and core versioning with changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "brew-lab/thaumic-cast" }],
   "commit": false,
-  "fixed": [["@thaumic-cast/desktop", "@thaumic-cast/extension"]],
+  "fixed": [["@thaumic-cast/desktop", "@thaumic-cast/extension", "@thaumic-cast/server"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -67,10 +67,11 @@ jobs:
           # Get version from desktop package (packages use fixed versioning)
           DESKTOP_VERSION=$(jq -r '.version' apps/desktop/package.json)
           EXTENSION_VERSION=$(jq -r '.version' apps/extension/package.json)
+          SERVER_VERSION=$(jq -r '.version' apps/server/package.json)
 
           # Verify versions are in sync (they should be with fixed config)
-          if [ "$DESKTOP_VERSION" != "$EXTENSION_VERSION" ]; then
-            echo "::error::Version mismatch! Desktop: $DESKTOP_VERSION, Extension: $EXTENSION_VERSION"
+          if [ "$DESKTOP_VERSION" != "$EXTENSION_VERSION" ] || [ "$DESKTOP_VERSION" != "$SERVER_VERSION" ]; then
+            echo "::error::Version mismatch! Desktop: $DESKTOP_VERSION, Extension: $EXTENSION_VERSION, Server: $SERVER_VERSION"
             exit 1
           fi
 

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thaumic-server"
-version = "0.1.0"
+version = "0.10.4"
 edition = "2021"
 description = "Standalone headless server for Thaumic Cast"
 license = "AGPL-3.0"

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thaumic-cast/server",
-  "version": "0.2.0",
+  "version": "0.10.4",
   "private": true,
   "author": {
     "name": "Brew",

--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,7 @@
     },
     "apps/server": {
       "name": "@thaumic-cast/server",
-      "version": "0.2.0",
+      "version": "0.10.4",
     },
     "packages/protocol": {
       "name": "@thaumic-cast/protocol",
@@ -89,6 +89,10 @@
       "devDependencies": {
         "typescript": "^5.0.0",
       },
+    },
+    "packages/thaumic-core": {
+      "name": "@thaumic-cast/core",
+      "version": "0.10.4",
     },
     "packages/ui": {
       "name": "@thaumic-cast/ui",
@@ -446,6 +450,8 @@
     "@tauri-apps/plugin-log": ["@tauri-apps/plugin-log@2.7.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-jdb+o0wxQc8PjnLktgGpOs9Dh1YupaOGDXzO+Y8peA1UZ1ep3eXv4E1oiJ7nIQVN0XUFDDhnn3aBszl8ijhR+A=="],
 
     "@tauri-apps/plugin-shell": ["@tauri-apps/plugin-shell@2.3.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-Xod+pRcFxmOWFWEnqH5yZcA7qwAMuaaDkMR1Sply+F8VfBj++CGnj2xf5UoialmjZ2Cvd8qrvSCbU+7GgNVsKQ=="],
+
+    "@thaumic-cast/core": ["@thaumic-cast/core@workspace:packages/thaumic-core"],
 
     "@thaumic-cast/desktop": ["@thaumic-cast/desktop@workspace:apps/desktop"],
 

--- a/packages/thaumic-core/package.json
+++ b/packages/thaumic-core/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@thaumic-cast/core",
+  "version": "0.10.4",
+  "private": true
+}


### PR DESCRIPTION
- Add server to fixed version group (desktop, extension, server)
- Sync server versions to 0.10.4 (package.json and Cargo.toml)
- Add stub package.json for thaumic-core changeset tracking
- Update sync-versions script to handle server and core
- Add server to version check in release workflow
