### PR TITLE
Feat(ext): alert and volume updates

### DIFF
--- a/.changeset/connection-status-refactor.md
+++ b/.changeset/connection-status-refactor.md
@@ -1,0 +1,21 @@
+---
+'@thaumic-cast/extension': patch
+'@thaumic-cast/ui': patch
+---
+
+Refactor connection status handling for better separation of concerns
+
+**Extension changes:**
+
+- Refactor `useConnectionStatus` hook to use reducer pattern for explicit state transitions
+- Remove i18n translation from hook; return error keys for component-level translation
+- Separate `WS_STATE_CHANGED` to only carry Sonos state (not connection metadata)
+- Add `CONNECTION_ATTEMPT_FAILED` message for explicit connection error handling
+- Replace `connected`/`checking` booleans with `phase` enum (`checking`, `reconnecting`, `connected`, `error`)
+- Add `canRetry` flag and `retry()` function to connection status
+- Add reconnecting state with user feedback when connection is temporarily lost
+- Fix race condition where WebSocket connects before `ENSURE_CONNECTION` response arrives
+
+**UI changes:**
+
+- Add inline action button support to Alert component (`action` and `onAction` props)

--- a/.changeset/volume-slider-stale-response.md
+++ b/.changeset/volume-slider-stale-response.md
@@ -1,0 +1,11 @@
+---
+'@thaumic-cast/ui': patch
+---
+
+Fix volume slider jumping from stale server responses
+
+Add interaction cooldown to the VolumeControl component that blocks external volume updates while the user is actively dragging the slider. Previously, server round-trip responses could override user input mid-drag, causing the slider to jump unexpectedly.
+
+- Track interaction state from pointer down through a 500ms cooldown after release
+- Queue external volume updates during interaction and apply after cooldown expires
+- Handle edge cases: pointer cancel, keyboard input, release without value change

--- a/apps/extension/src/background/offscreen-manager.ts
+++ b/apps/extension/src/background/offscreen-manager.ts
@@ -148,7 +148,10 @@ export async function recoverOffscreenState(): Promise<void> {
 
           // Notify popup of recovered state (it may already be open)
           if (status.connected) {
-            notifyPopup({ type: 'WS_STATE_CHANGED', state: status.state });
+            notifyPopup({
+              type: 'WS_STATE_CHANGED',
+              state: status.state,
+            });
           }
         }
 

--- a/apps/extension/src/lib/message-schemas.ts
+++ b/apps/extension/src/lib/message-schemas.ts
@@ -404,6 +404,15 @@ export const WsConnectionLostMessageSchema = z.object({
 });
 export type WsConnectionLostMessage = z.infer<typeof WsConnectionLostMessageSchema>;
 
+export const ConnectionAttemptFailedMessageSchema = z.object({
+  type: z.literal('CONNECTION_ATTEMPT_FAILED'),
+  /** The error key (for i18n lookup) or raw error message */
+  error: z.string(),
+  /** Whether manual retry is appropriate for this error type */
+  canRetry: z.boolean(),
+});
+export type ConnectionAttemptFailedMessage = z.infer<typeof ConnectionAttemptFailedMessageSchema>;
+
 export const NetworkHealthStatusSchema = z.enum(['ok', 'degraded']);
 export type NetworkHealthStatus = z.infer<typeof NetworkHealthStatusSchema>;
 

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -123,6 +123,8 @@ export {
   type SpeakerStopFailedMessage,
   WsConnectionLostMessageSchema,
   type WsConnectionLostMessage,
+  ConnectionAttemptFailedMessageSchema,
+  type ConnectionAttemptFailedMessage,
   NetworkHealthStatusSchema,
   type NetworkHealthStatus,
   NetworkEventMessageSchema,
@@ -203,6 +205,7 @@ import type {
   MuteUpdateMessage,
   TransportStateUpdateMessage,
   WsConnectionLostMessage,
+  ConnectionAttemptFailedMessage,
   NetworkHealthChangedMessage,
   LatencyUpdateMessage,
   LatencyStaleMessage,
@@ -268,6 +271,7 @@ export type BackgroundToPopupType =
   | 'MUTE_UPDATE'
   | 'TRANSPORT_STATE_UPDATE'
   | 'WS_CONNECTION_LOST'
+  | 'CONNECTION_ATTEMPT_FAILED'
   | 'NETWORK_HEALTH_CHANGED'
   | 'LATENCY_UPDATE'
   | 'LATENCY_STALE';
@@ -359,6 +363,7 @@ export type BackgroundToPopupMessage =
   | MuteUpdateMessage
   | TransportStateUpdateMessage
   | WsConnectionLostMessage
+  | ConnectionAttemptFailedMessage
   | NetworkHealthChangedMessage
   | LatencyUpdateMessage
   | LatencyStaleMessage

--- a/apps/extension/src/locales/en.json
+++ b/apps/extension/src/locales/en.json
@@ -16,9 +16,12 @@
   "status_disconnected": "Absent",
   "status_connected": "Present",
 
+  "warning_reconnecting": "The connection wandered off. We're fetching it.",
+
   "error_cast_failed": "The ritual failed to take hold",
-  "error_desktop_not_found": "The Desktop App appears to have wandered off",
-  "error_connection_lost": "The connection has wandered off",
+  "error_desktop_not_found": "The Desktop App has wandered off.",
+  "error_connection_lost": "The connection has wandered off.",
+  "retry_connection": "Reconnect",
   "error_no_active_tab": "Nothing here seems worth casting",
   "error_no_speakers_selected": "No speakers have been chosen for the ritual",
   "error_max_sessions": "Too many rituals in progress. Dispel one first.",

--- a/apps/extension/src/popup/hooks/useConnectionStatus.ts
+++ b/apps/extension/src/popup/hooks/useConnectionStatus.ts
@@ -1,6 +1,5 @@
-import { useState, useEffect } from 'preact/hooks';
-import { useTranslation } from 'react-i18next';
-import type { ConnectionState } from '../../background/connection-state';
+import { useReducer, useEffect, useCallback } from 'preact/hooks';
+import type { ConnectionState as BackgroundConnectionState } from '../../background/connection-state';
 import type { EnsureConnectionResponse } from '../../lib/messages';
 import { useChromeMessage } from './useChromeMessage';
 import { useMountedRef } from './useMountedRef';
@@ -9,15 +8,24 @@ import { useMountedRef } from './useMountedRef';
 export type NetworkHealthStatus = 'ok' | 'degraded';
 
 /**
+ * Connection phase representing the current state of desktop app connection.
+ * - `checking`: Initial connection attempt or user-triggered retry in progress
+ * - `reconnecting`: Had connection, lost it, auto-reconnect in progress
+ * - `connected`: Successfully connected to desktop app
+ * - `error`: Connection failed, user action may be needed
+ */
+export type ConnectionPhase = 'checking' | 'reconnecting' | 'connected' | 'error';
+
+/**
  * Connection status for the popup.
  */
 export interface ConnectionStatus {
-  /** Whether WebSocket is currently connected */
-  connected: boolean;
-  /** Whether we're actively checking connection (only on first load) */
-  checking: boolean;
-  /** Error message if any */
+  /** Current connection phase */
+  phase: ConnectionPhase;
+  /** Error key or message (only set when phase === 'error'). Use with t(error, { defaultValue: error }) */
   error: string | null;
+  /** Whether manual retry is available (only relevant when phase === 'error') */
+  canRetry: boolean;
   /** Desktop app URL if discovered */
   desktopAppUrl: string | null;
   /** Maximum concurrent streams allowed */
@@ -26,6 +34,120 @@ export interface ConnectionStatus {
   networkHealth: NetworkHealthStatus;
   /** Reason for degraded network health (null if healthy) */
   networkHealthReason: string | null;
+  /** Triggers a connection retry attempt (sets phase to 'checking') */
+  retry: () => Promise<void>;
+}
+
+/** Internal state managed by the reducer */
+interface ConnectionState {
+  phase: ConnectionPhase;
+  error: string | null;
+  canRetry: boolean;
+  desktopAppUrl: string | null;
+  maxStreams: number | null;
+  networkHealth: NetworkHealthStatus;
+  networkHealthReason: string | null;
+}
+
+/** Actions that can update connection state */
+type ConnectionAction =
+  | { type: 'RETRY_STARTED' }
+  | { type: 'CACHED_STATE_RECEIVED'; payload: BackgroundConnectionState }
+  | { type: 'CONNECTION_RESPONSE'; payload: EnsureConnectionResponse }
+  | { type: 'RUNTIME_ERROR'; error: string }
+  | { type: 'WS_CONNECTED' }
+  | { type: 'WS_RECONNECTING' }
+  | { type: 'WS_PERMANENTLY_LOST' }
+  | { type: 'CONNECTION_FAILED'; error: string; canRetry: boolean }
+  | { type: 'NETWORK_HEALTH_CHANGED'; health: NetworkHealthStatus; reason: string | null };
+
+const initialState: ConnectionState = {
+  phase: 'checking',
+  error: null,
+  canRetry: false,
+  desktopAppUrl: null,
+  maxStreams: null,
+  networkHealth: 'ok',
+  networkHealthReason: null,
+};
+
+/**
+ * Derives connection phase from connection flags.
+ * @param connected
+ * @param hasError
+ */
+function derivePhase(connected: boolean, hasError: boolean): ConnectionPhase {
+  if (connected) return 'connected';
+  if (hasError) return 'error';
+  return 'checking';
+}
+
+/**
+ * Reducer for connection state transitions.
+ * Centralizes all state update logic for easier testing and reasoning.
+ * @param state
+ * @param action
+ */
+function connectionReducer(state: ConnectionState, action: ConnectionAction): ConnectionState {
+  switch (action.type) {
+    case 'RETRY_STARTED':
+      return { ...state, phase: 'checking', error: null, canRetry: false };
+
+    case 'CACHED_STATE_RECEIVED': {
+      const {
+        connected,
+        lastError,
+        desktopAppUrl,
+        maxStreams,
+        networkHealth,
+        networkHealthReason,
+      } = action.payload;
+      if (!desktopAppUrl) return state;
+      return {
+        ...state,
+        phase: derivePhase(connected, !!lastError),
+        error: lastError ?? null,
+        canRetry: !!lastError,
+        desktopAppUrl,
+        maxStreams,
+        networkHealth: networkHealth ?? 'ok',
+        networkHealthReason: networkHealthReason ?? null,
+      };
+    }
+
+    case 'CONNECTION_RESPONSE': {
+      const { connected, error, desktopAppUrl, maxStreams } = action.payload;
+      return {
+        ...state,
+        phase: derivePhase(connected, !!error),
+        error: error ?? null,
+        canRetry: !!error,
+        desktopAppUrl: desktopAppUrl ?? state.desktopAppUrl,
+        maxStreams: maxStreams ?? state.maxStreams,
+      };
+    }
+
+    case 'RUNTIME_ERROR':
+      return { ...state, phase: 'error', error: action.error, canRetry: false };
+
+    case 'WS_CONNECTED':
+      return { ...state, phase: 'connected', error: null, canRetry: false };
+
+    case 'WS_RECONNECTING':
+      return { ...state, phase: 'reconnecting', error: null, canRetry: false };
+
+    case 'WS_PERMANENTLY_LOST':
+      return { ...state, phase: 'error', error: 'error_connection_lost', canRetry: true };
+
+    case 'CONNECTION_FAILED':
+      return { ...state, phase: 'error', error: action.error, canRetry: action.canRetry };
+
+    case 'NETWORK_HEALTH_CHANGED':
+      return { ...state, networkHealth: action.health, networkHealthReason: action.reason };
+
+    default:
+      return state;
+  }
 }
 
 /**
@@ -34,105 +156,100 @@ export interface ConnectionStatus {
  * Uses cached connection state from background for instant UI rendering,
  * only showing "Checking..." on first-ever connection.
  *
- * @returns Current connection status
+ * @returns Current connection status including retry function
  */
 export function useConnectionStatus(): ConnectionStatus {
-  const { t } = useTranslation();
-  const [status, setStatus] = useState<ConnectionStatus>({
-    connected: false,
-    checking: true,
-    error: null,
-    desktopAppUrl: null,
-    maxStreams: null,
-    networkHealth: 'ok',
-    networkHealthReason: null,
-  });
+  const [state, dispatch] = useReducer(connectionReducer, initialState);
   const mountedRef = useMountedRef();
 
+  /** Triggers a connection retry attempt. */
+  const retry = useCallback(async () => {
+    dispatch({ type: 'RETRY_STARTED' });
+    try {
+      await chrome.runtime.sendMessage({ type: 'ENSURE_CONNECTION' });
+      // State will be updated by broadcast messages (WS_STATE_CHANGED, CONNECTION_ATTEMPT_FAILED, etc.)
+    } catch (err) {
+      if (!mountedRef.current) return;
+      const error = err instanceof Error ? err.message : String(err);
+      dispatch({ type: 'RUNTIME_ERROR', error });
+    }
+  }, [mountedRef]);
+
+  // Initialize connection on mount
   useEffect(() => {
-    /** Initializes connection status from background state. */
+    /**
+     *
+     */
     async function init() {
       try {
-        const cached: ConnectionState = await chrome.runtime.sendMessage({
+        // Fetch cached state for instant display
+        const cached: BackgroundConnectionState = await chrome.runtime.sendMessage({
           type: 'GET_CONNECTION_STATUS',
         });
-
         if (!mountedRef.current) return;
+        dispatch({ type: 'CACHED_STATE_RECEIVED', payload: cached });
 
-        if (cached.desktopAppUrl) {
-          setStatus({
-            connected: cached.connected,
-            checking: !cached.connected,
-            error: cached.lastError ? t(cached.lastError) : null,
-            desktopAppUrl: cached.desktopAppUrl,
-            maxStreams: cached.maxStreams,
-            networkHealth: cached.networkHealth ?? 'ok',
-            networkHealthReason: cached.networkHealthReason ?? null,
-          });
-        }
-
+        // Trigger connection if needed
         const response: EnsureConnectionResponse = await chrome.runtime.sendMessage({
           type: 'ENSURE_CONNECTION',
         });
-
         if (!mountedRef.current) return;
-
-        setStatus((s) => ({
-          ...s,
-          checking: !response.connected && !response.error,
-          error: response.error ? t(response.error) : null,
-          desktopAppUrl: response.desktopAppUrl ?? s.desktopAppUrl,
-          maxStreams: response.maxStreams ?? s.maxStreams,
-        }));
+        dispatch({ type: 'CONNECTION_RESPONSE', payload: response });
       } catch (err) {
         if (!mountedRef.current) return;
-        const message = err instanceof Error ? err.message : String(err);
-        setStatus((s) => ({
-          ...s,
-          checking: false,
-          error: message,
-        }));
+        const error = err instanceof Error ? err.message : String(err);
+        dispatch({ type: 'RUNTIME_ERROR', error });
       }
     }
 
     init();
   }, []);
 
+  // Listen for connection-related broadcast messages
   useChromeMessage((message) => {
     const msg = message as { type: string; [key: string]: unknown };
     switch (msg.type) {
       case 'WS_STATE_CHANGED':
-        setStatus((s) => ({
-          ...s,
-          connected: true,
-          checking: false,
-          error: null,
-        }));
+        dispatch({ type: 'WS_CONNECTED' });
+        // Fetch connection metadata in case ENSURE_CONNECTION response hasn't arrived yet
+        // (race condition: WS connects before response is processed)
+        chrome.runtime
+          .sendMessage({ type: 'GET_CONNECTION_STATUS' })
+          .then((status: BackgroundConnectionState) => {
+            if (mountedRef.current && status.desktopAppUrl) {
+              dispatch({ type: 'CACHED_STATE_RECEIVED', payload: status });
+            }
+          })
+          .catch(() => {});
         break;
 
       case 'WS_CONNECTION_LOST': {
         const reason = msg.reason as string;
-        setStatus((s) => ({
-          ...s,
-          connected: false,
-          checking: false,
-          error: reason === 'max_retries_exceeded' ? t('error_connection_lost') : null,
-        }));
+        if (reason === 'max_retries_exceeded') {
+          dispatch({ type: 'WS_PERMANENTLY_LOST' });
+        } else {
+          dispatch({ type: 'WS_RECONNECTING' });
+        }
         break;
       }
 
-      case 'NETWORK_HEALTH_CHANGED': {
-        const health = msg.health as NetworkHealthStatus;
-        const reason = msg.reason as string | null;
-        setStatus((s) => ({
-          ...s,
-          networkHealth: health,
-          networkHealthReason: reason,
-        }));
+      case 'CONNECTION_ATTEMPT_FAILED':
+        dispatch({
+          type: 'CONNECTION_FAILED',
+          error: msg.error as string,
+          canRetry: msg.canRetry as boolean,
+        });
         break;
-      }
+
+      case 'NETWORK_HEALTH_CHANGED':
+        dispatch({
+          type: 'NETWORK_HEALTH_CHANGED',
+          health: msg.health as NetworkHealthStatus,
+          reason: msg.reason as string | null,
+        });
+        break;
     }
   });
 
-  return status;
+  return { ...state, retry };
 }

--- a/packages/ui/src/Alert/Alert.module.css
+++ b/packages/ui/src/Alert/Alert.module.css
@@ -18,6 +18,7 @@
   flex: 1;
   min-inline-size: 0;
   text-wrap: pretty;
+  user-select: text;
 }
 
 .dismiss {

--- a/packages/ui/src/Alert/Alert.module.css
+++ b/packages/ui/src/Alert/Alert.module.css
@@ -21,6 +21,23 @@
   user-select: text;
 }
 
+.action {
+  display: inline;
+  margin-inline-start: 0.5em;
+  padding: 0;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  opacity: 0.9;
+}
+
+.action:hover {
+  opacity: 1;
+}
+
 .dismiss {
   flex-shrink: 0;
   margin-inline-start: var(--space-xs);

--- a/packages/ui/src/Alert/Alert.tsx
+++ b/packages/ui/src/Alert/Alert.tsx
@@ -15,6 +15,10 @@ interface AlertProps {
   className?: string;
   /** Callback when dismiss button is clicked. If provided, shows a dismiss button. */
   onDismiss?: () => void;
+  /** Action button label. If provided along with onAction, shows an inline action button. */
+  action?: string;
+  /** Callback when action button is clicked */
+  onAction?: () => void;
 }
 
 const VARIANT_CLASSES: Record<AlertVariant, string> = {
@@ -38,16 +42,32 @@ const VARIANT_ICONS: Record<AlertVariant, FunctionComponent<LucideProps>> = {
  * @param props.variant - Visual variant (default: warning)
  * @param props.className - Additional CSS class
  * @param props.onDismiss - Callback when dismiss button is clicked
+ * @param props.action - Action button label
+ * @param props.onAction - Callback when action button is clicked
  * @returns The rendered Alert component
  */
-export function Alert({ children, variant = 'warning', className, onDismiss }: AlertProps) {
+export function Alert({
+  children,
+  variant = 'warning',
+  className,
+  onDismiss,
+  action,
+  onAction,
+}: AlertProps) {
   const variantClass = VARIANT_CLASSES[variant];
   const Icon = VARIANT_ICONS[variant];
 
   return (
     <div className={[styles.alert, variantClass, className].filter(Boolean).join(' ')} role="alert">
       <Icon size={16} className={styles.icon} aria-hidden="true" />
-      <div className={styles.content}>{children}</div>
+      <div className={styles.content}>
+        {children}
+        {action && onAction && (
+          <button type="button" className={styles.action} onClick={onAction}>
+            {action}
+          </button>
+        )}
+      </div>
       {onDismiss && (
         <IconButton size="sm" className={styles.dismiss} onClick={onDismiss} aria-label="Dismiss">
           <X size={14} aria-hidden="true" />


### PR DESCRIPTION
## What

- Refactor `useConnectionStatus` hook to use reducer pattern for explicit state transitions
- Remove i18n translation from hook; return error keys for component-level translation
- Separate `WS_STATE_CHANGED` to only carry Sonos state (not connection metadata)
- Add `CONNECTION_ATTEMPT_FAILED` message for explicit connection error handling
- Replace `connected`/`checking` booleans with `phase` enum (`checking`, `reconnecting`, `connected`, `error`)
- Add `canRetry` flag and `retry()` function to connection status
- Add reconnecting state with user feedback when connection is temporarily lost
- Fix race condition where WebSocket connects before `ENSURE_CONNECTION` response arrives

