### PR TITLE
feat(core,ui): detect and handle fixed volume Sonos speakers

### DIFF
--- a/.changeset/fixed-volume-support.md
+++ b/.changeset/fixed-volume-support.md
@@ -1,0 +1,16 @@
+---
+'@thaumic-cast/extension': minor
+'@thaumic-cast/protocol': minor
+'@thaumic-cast/ui': minor
+---
+
+Add fixed volume detection for Sonos speakers with line-level output
+
+Sonos devices like CONNECT and Port have fixed line-level output where volume cannot be adjusted via API. This change detects and handles these speakers:
+
+- Parse `OutputFixed` from GENA GroupRenderingControl notifications
+- Propagate `fixed` state through the event system alongside volume updates
+- Disable volume controls in the UI for fixed-output speakers
+- Add `disabled` prop to `VolumeControl` and `SpeakerVolumeRow` components
+
+When a speaker has fixed volume, the volume slider and mute button are visually disabled and non-interactive.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5060,7 +5060,7 @@ dependencies = [
 
 [[package]]
 name = "thaumic-cast-desktop"
-version = "0.10.4"
+version = "0.11.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5135,7 +5135,7 @@ dependencies = [
 
 [[package]]
 name = "thaumic-server"
-version = "0.1.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/apps/extension/src/background/sonos-event-handlers.ts
+++ b/apps/extension/src/background/sonos-event-handlers.ts
@@ -25,6 +25,7 @@ import {
   updateGroups,
   updateVolume,
   updateMute,
+  updateVolumeFixed,
   updateTransportState,
   getSonosState,
 } from './sonos-state';
@@ -72,7 +73,11 @@ export async function handleSonosEvent(event: BroadcastEvent): Promise<void> {
         break;
 
       case 'groupVolume':
-        handleGroupVolume(eventData.speakerIp as string, eventData.volume as number);
+        handleGroupVolume(
+          eventData.speakerIp as string,
+          eventData.volume as number,
+          eventData.fixed as boolean | undefined,
+        );
         break;
 
       case 'groupMute':
@@ -293,14 +298,20 @@ async function handleSourceChanged(speakerIp: string, currentUri: string): Promi
  * Handles volume change events.
  * @param speakerIp - The speaker IP address
  * @param volume - The new volume (0-100)
+ * @param fixed - Whether volume is fixed (line-level output)
  */
-function handleGroupVolume(speakerIp: string, volume: number): void {
+function handleGroupVolume(speakerIp: string, volume: number, fixed?: boolean): void {
   updateVolume(speakerIp, volume);
+
+  if (fixed !== undefined) {
+    updateVolumeFixed(speakerIp, fixed);
+  }
 
   notifyPopup({
     type: 'VOLUME_UPDATE',
     speakerIp,
     volume,
+    fixed,
   });
 }
 

--- a/apps/extension/src/background/sonos-state.ts
+++ b/apps/extension/src/background/sonos-state.ts
@@ -125,3 +125,18 @@ export function updateTransportState(
   storage.schedule();
   return state;
 }
+
+/**
+ * Updates fixed volume state for a specific speaker.
+ * @param speakerIp - The speaker IP address
+ * @param fixed - Whether volume is fixed (line-level output)
+ * @returns The updated state
+ */
+export function updateVolumeFixed(speakerIp: string, fixed: boolean): SonosStateSnapshot {
+  state = {
+    ...state,
+    groupVolumeFixed: { ...state.groupVolumeFixed, [speakerIp]: fixed },
+  };
+  storage.schedule();
+  return state;
+}

--- a/apps/extension/src/lib/message-schemas.ts
+++ b/apps/extension/src/lib/message-schemas.ts
@@ -342,6 +342,7 @@ export const VolumeUpdateMessageSchema = z.object({
   type: z.literal('VOLUME_UPDATE'),
   speakerIp: SpeakerIpSchema,
   volume: VolumeSchema,
+  fixed: z.boolean().optional(),
 });
 export type VolumeUpdateMessage = z.infer<typeof VolumeUpdateMessageSchema>;
 

--- a/apps/extension/src/popup/App.tsx
+++ b/apps/extension/src/popup/App.tsx
@@ -98,6 +98,7 @@ function MainPopup(): JSX.Element {
     loading: sonosLoading,
     getVolume,
     getMuted: isMuted,
+    getVolumeFixed,
     getTransportState,
     setVolume: handleVolumeChange,
     setMuted,
@@ -272,6 +273,7 @@ function MainPopup(): JSX.Element {
         getTransportState={getTransportState}
         getVolume={getVolume}
         isMuted={isMuted}
+        getVolumeFixed={getVolumeFixed}
         onVolumeChange={handleVolumeChange}
         onMuteToggle={handleMuteToggle}
         onStopCast={stopCast}

--- a/apps/extension/src/popup/components/ActiveCastCard.tsx
+++ b/apps/extension/src/popup/components/ActiveCastCard.tsx
@@ -24,6 +24,8 @@ interface ActiveCastCardProps {
   getVolume: (speakerIp: string) => number;
   /** Function to check if a speaker is muted */
   isMuted: (speakerIp: string) => boolean;
+  /** Function to check if a speaker has fixed volume (line-level output) */
+  getVolumeFixed?: (speakerIp: string) => boolean;
   /** Callback when volume changes for a speaker */
   onVolumeChange: (speakerIp: string, volume: number) => void;
   /** Callback when mute is toggled for a speaker */
@@ -45,6 +47,7 @@ interface ActiveCastCardProps {
  * @param props.getTransportState
  * @param props.getVolume
  * @param props.isMuted
+ * @param props.getVolumeFixed
  * @param props.onVolumeChange
  * @param props.onMuteToggle
  * @param props.onStop
@@ -58,6 +61,7 @@ export function ActiveCastCard({
   getTransportState,
   getVolume,
   isMuted,
+  getVolumeFixed,
   onVolumeChange,
   onMuteToggle,
   onStop,
@@ -253,6 +257,7 @@ export function ActiveCastCard({
                 speakerIp={ip}
                 volume={getVolume(ip)}
                 muted={isMuted(ip)}
+                disabled={getVolumeFixed?.(ip)}
                 onVolumeChange={(vol) => onVolumeChange(ip, vol)}
                 onMuteToggle={() => onMuteToggle(ip)}
                 muteLabel={t('mute_speaker', { name })}

--- a/apps/extension/src/popup/components/ActiveCastsList.tsx
+++ b/apps/extension/src/popup/components/ActiveCastsList.tsx
@@ -13,6 +13,8 @@ interface ActiveCastsListProps {
   getVolume: (speakerIp: string) => number;
   /** Function to check if a speaker is muted */
   isMuted: (speakerIp: string) => boolean;
+  /** Function to check if a speaker has fixed volume (line-level output) */
+  getVolumeFixed?: (speakerIp: string) => boolean;
   /** Callback when volume changes for a speaker */
   onVolumeChange: (speakerIp: string, volume: number) => void;
   /** Callback when mute is toggled for a speaker */
@@ -36,6 +38,7 @@ interface ActiveCastsListProps {
  * @param props.getTransportState
  * @param props.getVolume
  * @param props.isMuted
+ * @param props.getVolumeFixed
  * @param props.onVolumeChange
  * @param props.onMuteToggle
  * @param props.onStopCast
@@ -50,6 +53,7 @@ export function ActiveCastsList({
   getTransportState,
   getVolume,
   isMuted,
+  getVolumeFixed,
   onVolumeChange,
   onMuteToggle,
   onStopCast,
@@ -75,6 +79,7 @@ export function ActiveCastsList({
               getTransportState={getTransportState}
               getVolume={getVolume}
               isMuted={isMuted}
+              getVolumeFixed={getVolumeFixed}
               onVolumeChange={onVolumeChange}
               onMuteToggle={onMuteToggle}
               onStop={() => onStopCast(cast.tabId)}

--- a/apps/extension/src/popup/hooks/useSonosState.ts
+++ b/apps/extension/src/popup/hooks/useSonosState.ts
@@ -26,6 +26,8 @@ interface SonosStateResult {
   getVolume: (speakerIp: string) => number;
   /** Get mute state for a speaker */
   getMuted: (speakerIp: string) => boolean;
+  /** Get whether volume is fixed (line-level output) for a speaker */
+  getVolumeFixed: (speakerIp: string) => boolean;
   /** Get transport state for a speaker */
   getTransportState: (speakerIp: string) => TransportState | undefined;
   /** Set volume for a speaker */
@@ -64,10 +66,13 @@ export function useSonosState(): SonosStateResult {
         break;
       }
       case 'VOLUME_UPDATE': {
-        const { speakerIp, volume } = message as VolumeUpdateMessage;
+        const { speakerIp, volume, fixed } = message as VolumeUpdateMessage;
         setState((prev) => ({
           ...prev,
           groupVolumes: { ...prev.groupVolumes, [speakerIp]: volume },
+          ...(fixed !== undefined && {
+            groupVolumeFixed: { ...prev.groupVolumeFixed, [speakerIp]: fixed },
+          }),
         }));
         break;
       }
@@ -98,6 +103,11 @@ export function useSonosState(): SonosStateResult {
   const getMuted = useCallback(
     (speakerIp: string): boolean => state.groupMutes[speakerIp] ?? false,
     [state.groupMutes],
+  );
+
+  const getVolumeFixed = useCallback(
+    (speakerIp: string): boolean => state.groupVolumeFixed[speakerIp] ?? false,
+    [state.groupVolumeFixed],
   );
 
   const getTransportState = useCallback(
@@ -135,6 +145,7 @@ export function useSonosState(): SonosStateResult {
     loading,
     getVolume,
     getMuted,
+    getVolumeFixed,
     getTransportState,
     setVolume,
     setMuted,

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -32,6 +32,7 @@ export const SonosEventSchema = z.discriminatedUnion('type', [
     type: z.literal('groupVolume'),
     speakerIp: z.string(),
     volume: z.number(),
+    fixed: z.boolean().optional(),
     timestamp: z.number(),
   }),
   z.object({

--- a/packages/protocol/src/sonos.ts
+++ b/packages/protocol/src/sonos.ts
@@ -73,6 +73,7 @@ export const SonosStateSnapshotSchema = z.object({
   transportStates: z.record(z.string(), TransportStateSchema),
   groupVolumes: z.record(z.string(), z.number()),
   groupMutes: z.record(z.string(), z.boolean()),
+  groupVolumeFixed: z.record(z.string(), z.boolean()),
   sessions: z.array(PlaybackSessionSchema).optional(),
 });
 export type SonosStateSnapshot = z.infer<typeof SonosStateSnapshotSchema>;
@@ -87,6 +88,7 @@ export function createEmptySonosState(): SonosStateSnapshot {
     groups: [],
     groupVolumes: {},
     groupMutes: {},
+    groupVolumeFixed: {},
     transportStates: {},
   };
 }
@@ -100,6 +102,7 @@ export const InitialStatePayloadSchema = z.object({
   transportStates: z.record(z.string(), TransportStateSchema),
   groupVolumes: z.record(z.string(), z.number()),
   groupMutes: z.record(z.string(), z.boolean()),
+  groupVolumeFixed: z.record(z.string(), z.boolean()),
   sessions: z.array(PlaybackSessionSchema).optional(),
 });
 export type InitialStatePayload = z.infer<typeof InitialStatePayloadSchema>;

--- a/packages/thaumic-core/src/services/gena_event_processor.rs
+++ b/packages/thaumic-core/src/services/gena_event_processor.rs
@@ -102,16 +102,25 @@ impl GenaEventProcessor {
                     .insert(speaker_ip.clone(), *transport_state);
             }
             SonosEvent::GroupVolume {
-                speaker_ip, volume, ..
+                speaker_ip,
+                volume,
+                fixed,
+                ..
             } => {
                 log::info!(
-                    "[GenaEventProcessor] Group volume change: {} -> {}",
+                    "[GenaEventProcessor] Group volume change: {} -> {} (fixed: {:?})",
                     speaker_ip,
-                    volume
+                    volume,
+                    fixed
                 );
                 deps.sonos_state
                     .group_volumes
                     .insert(speaker_ip.clone(), *volume);
+                if let Some(is_fixed) = fixed {
+                    deps.sonos_state
+                        .group_volume_fixed
+                        .insert(speaker_ip.clone(), *is_fixed);
+                }
             }
             SonosEvent::GroupMute {
                 speaker_ip, muted, ..

--- a/packages/thaumic-core/src/sonos/gena.rs
+++ b/packages/thaumic-core/src/sonos/gena.rs
@@ -64,6 +64,9 @@ pub enum SonosEvent {
         #[serde(rename = "speakerIp")]
         speaker_ip: String,
         volume: u8,
+        /// Whether the output is fixed (line-level, cannot be adjusted).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        fixed: Option<bool>,
         timestamp: u64,
     },
     /// Group mute state changed (from coordinator).

--- a/packages/thaumic-core/src/sonos/gena_event_builder.rs
+++ b/packages/thaumic-core/src/sonos/gena_event_builder.rs
@@ -81,6 +81,7 @@ pub fn build_group_rendering_events(ip: &str, body: &str) -> Vec<SonosEvent> {
         events.push(SonosEvent::GroupVolume {
             speaker_ip: ip.to_string(),
             volume,
+            fixed: data.output_fixed,
             timestamp,
         });
     }

--- a/packages/thaumic-core/src/sonos/gena_parser.rs
+++ b/packages/thaumic-core/src/sonos/gena_parser.rs
@@ -23,6 +23,8 @@ pub struct GroupRenderingData {
     pub volume: Option<u8>,
     /// Group mute state.
     pub muted: Option<bool>,
+    /// Whether the output is fixed (line-level, cannot be adjusted).
+    pub output_fixed: Option<bool>,
 }
 
 /// Parses an AVTransport NOTIFY event body.
@@ -71,6 +73,10 @@ pub fn parse_group_rendering_control(body: &str) -> GroupRenderingData {
 
     if let Some(mute_str) = extract_xml_text(body, "GroupMute") {
         data.muted = Some(mute_str == "1");
+    }
+
+    if let Some(fixed_str) = extract_xml_text(body, "OutputFixed") {
+        data.output_fixed = Some(fixed_str == "1");
     }
 
     data

--- a/packages/thaumic-core/src/state.rs
+++ b/packages/thaumic-core/src/state.rs
@@ -197,6 +197,9 @@ pub struct SonosState {
     pub group_volumes: DashMap<String, u8>,
     /// Map of coordinator IP to their group mute status.
     pub group_mutes: DashMap<String, bool>,
+    /// Map of coordinator IP to their fixed volume status.
+    /// True indicates volume cannot be adjusted (line-level output).
+    pub group_volume_fixed: DashMap<String, bool>,
 }
 
 impl SonosState {
@@ -209,6 +212,7 @@ impl SonosState {
             "transportStates": dashmap_to_json(&self.transport_states),
             "groupVolumes": dashmap_to_json(&self.group_volumes),
             "groupMutes": dashmap_to_json(&self.group_mutes),
+            "groupVolumeFixed": dashmap_to_json(&self.group_volume_fixed),
         })
     }
 
@@ -229,10 +233,12 @@ impl SonosState {
         self.transport_states
             .retain(|ip, _| valid_speaker_ips.contains(ip));
 
-        // Volume and mute are per-coordinator (only coordinators control group volume)
+        // Volume, mute, and fixed are per-coordinator (only coordinators control group volume)
         self.group_volumes
             .retain(|ip, _| valid_coordinator_ips.contains(ip));
         self.group_mutes
+            .retain(|ip, _| valid_coordinator_ips.contains(ip));
+        self.group_volume_fixed
             .retain(|ip, _| valid_coordinator_ips.contains(ip));
     }
 

--- a/packages/ui/src/Speaker/SpeakerVolumeRow.tsx
+++ b/packages/ui/src/Speaker/SpeakerVolumeRow.tsx
@@ -13,6 +13,8 @@ interface SpeakerVolumeRowProps {
   volume: number;
   /** Whether speaker is muted */
   muted: boolean;
+  /** Whether volume controls are disabled (e.g., fixed line-level output) */
+  disabled?: boolean;
   /** Callback when volume changes */
   onVolumeChange: (volume: number) => void;
   /** Callback when mute is toggled */
@@ -40,6 +42,7 @@ interface SpeakerVolumeRowProps {
  * @param props.speakerIp - Speaker coordinator IP
  * @param props.volume - Current volume level
  * @param props.muted - Whether muted
+ * @param props.disabled
  * @param props.onVolumeChange - Volume change callback
  * @param props.onMuteToggle - Mute toggle callback
  * @param props.muteLabel - Accessible label for mute button (include speaker name)
@@ -56,6 +59,7 @@ export function SpeakerVolumeRow({
   speakerIp,
   volume,
   muted,
+  disabled,
   onVolumeChange,
   onMuteToggle,
   muteLabel,
@@ -91,6 +95,7 @@ export function SpeakerVolumeRow({
       <VolumeControl
         volume={volume}
         muted={muted}
+        disabled={disabled}
         onVolumeChange={onVolumeChange}
         onMuteToggle={onMuteToggle}
         muteLabel={muteLabel}

--- a/packages/ui/src/VolumeControl/VolumeControl.module.css
+++ b/packages/ui/src/VolumeControl/VolumeControl.module.css
@@ -13,6 +13,11 @@
   opacity: var(--state-muted-opacity);
 }
 
+.disabled {
+  opacity: var(--input-disabled-opacity);
+  cursor: not-allowed;
+}
+
 .slider {
   --volume: 0%;
   --touch-offset: calc((var(--touch-target-size) - var(--slider-track-height)) / 2);
@@ -63,6 +68,10 @@
   box-shadow:
     0 0 0 2px var(--color-bg),
     0 0 0 4px var(--color-focus);
+}
+
+.disabled .slider {
+  pointer-events: none;
 }
 
 .value {

--- a/packages/ui/src/VolumeControl/VolumeControl.tsx
+++ b/packages/ui/src/VolumeControl/VolumeControl.tsx
@@ -26,6 +26,8 @@ interface VolumeControlProps {
   onVolumeChange: (volume: number) => void;
   /** Callback when mute is toggled */
   onMuteToggle: () => void;
+  /** Whether controls are disabled (e.g., fixed line-level output) */
+  disabled?: boolean;
   /** Label for mute button when unmuted */
   muteLabel?: string;
   /** Label for mute button when muted */
@@ -43,6 +45,7 @@ interface VolumeControlProps {
  * @param props.muted - Whether muted
  * @param props.onVolumeChange - Volume change handler
  * @param props.onMuteToggle - Mute toggle handler
+ * @param props.disabled
  * @param props.muteLabel - Label for mute action
  * @param props.unmuteLabel - Label for unmute action
  * @param props.volumeLabel - Accessible label for the volume slider
@@ -54,6 +57,7 @@ export function VolumeControl({
   muted,
   onVolumeChange,
   onMuteToggle,
+  disabled = false,
   muteLabel = 'Mute',
   unmuteLabel = 'Unmute',
   volumeLabel = 'Volume',
@@ -189,11 +193,16 @@ export function VolumeControl({
   }, [endInteraction]);
 
   return (
-    <div className={[styles.volumeControl, className].filter(Boolean).join(' ')}>
+    <div
+      className={[styles.volumeControl, disabled && styles.disabled, className]
+        .filter(Boolean)
+        .join(' ')}
+    >
       <IconButton
         size="sm"
         className={[styles.muteBtn, muted ? styles.muted : ''].filter(Boolean).join(' ')}
         onClick={handleMuteToggle}
+        disabled={disabled}
         title={muted ? unmuteLabel : muteLabel}
         aria-label={muted ? unmuteLabel : muteLabel}
       >
@@ -208,6 +217,7 @@ export function VolumeControl({
         onPointerDown={handlePointerDown}
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerUp}
+        disabled={disabled}
         className={styles.slider}
         style={{ '--volume': `${localVolume}%` } as CSSProperties}
         aria-label={volumeLabel}


### PR DESCRIPTION
Add support for Sonos devices with fixed line-level output (CONNECT, Port) where volume cannot be adjusted via API:

- Parse OutputFixed from GENA GroupRenderingControl notifications
- Add fixed field to GroupVolume event and groupVolumeFixed to state
- Propagate fixed state through WebSocket to extension
- Add disabled prop to VolumeControl and SpeakerVolumeRow components
- Disable volume controls in UI for fixed-output speakers

