### PR TITLE
feat(extension): add MSTP pipeline for PCM codec

### DIFF
--- a/.changeset/mstp-pcm-pipeline.md
+++ b/.changeset/mstp-pcm-pipeline.md
@@ -1,0 +1,21 @@
+---
+'@thaumic-cast/extension': minor
+---
+
+Add MSTP audio pipeline for PCM streaming to eliminate crackling artifacts
+
+The previous PCM path routed captured audio through `AudioContext` + `AudioWorklet` + `SharedArrayBuffer`, which crosses a clock domain between the MediaStream and AudioContext clocks. When the two clocks drifted, the worklet would emit zero-filled audio blocks, producing audible crackling.
+
+This replaces the PCM path with a `MediaStreamTrackProcessor` (MSTP) pipeline that reads `AudioData` at the MediaStream's native rate — no clock crossing, no zero-fills. Compressed codecs continue to use the existing AudioContext path because their encoders run in the worklet.
+
+**New:**
+
+- `audio-relay.worker.ts`: purpose-built worker that consumes the transferred `ReadableStream<AudioData>`, extracts f32-planar channels, interleaves with TPDF dither, quantizes to Int16, and sends fixed-size frames over WebSocket.
+- `keepTabAudible` in MSTP mode uses a low-volume `<audio>` element instead of an AudioContext gain node to avoid reintroducing the clock crossing.
+
+**Supporting refactors:**
+
+- Extracted `worker-base.ts` from `audio-consumer.worker.ts` — shared WebSocket lifecycle, frame queue, backpressure handling, stats/metrics timeline, and common message handling are now reusable across consumer worker implementations.
+- Added `MetricSnapshot` + `WorkerMetricsDumpMessage` for post-session analysis.
+- Tightened encoder interface and worker frame-queue types to `Uint8Array<ArrayBuffer>` so encoded audio flows to `WebSocket.send()` without casts (required by TypeScript 5.7+).
+- Audio relay accumulator now owns its backing `ArrayBuffer` explicitly, matching the PCM encoder pattern and eliminating the last inline cast in the hot path.

--- a/apps/extension/src/offscreen/audio-consumer.worker.ts
+++ b/apps/extension/src/offscreen/audio-consumer.worker.ts
@@ -6,8 +6,8 @@
  * off the main thread, eliminating jitter from main thread blocking.
  *
  * Architecture:
- *   AudioWorklet → SharedArrayBuffer → Worker (drain + encode + websocket send)
- *                                         ↓
+ *   AudioWorklet -> SharedArrayBuffer -> Worker (drain + encode + websocket send)
+ *                                         |
  *                              Main thread only for:
  *                              - Stats logging
  *                              - Control messages
@@ -20,19 +20,31 @@ import {
   DATA_BYTE_OFFSET,
 } from './ring-buffer';
 import { createEncoder, type AudioEncoder } from './encoders';
-import type { AudioCodec, EncoderConfig, WsMessage } from '@thaumic-cast/protocol';
-import type { WorkerInboundMessage, WorkerOutboundMessage } from './worker-messages';
-import {
-  WsMessageSchema,
-  getStreamingPolicy,
-  type StreamingPolicy,
-  FRAME_DURATION_MS_DEFAULT,
-  FRAME_QUEUE_HYSTERESIS_RATIO,
-} from '@thaumic-cast/protocol';
-import { createLogger } from '@thaumic-cast/shared';
+import type { AudioCodec, EncoderConfig } from '@thaumic-cast/protocol';
+import type { WorkerInboundMessage } from './worker-messages';
+import { getStreamingPolicy, FRAME_DURATION_MS_DEFAULT } from '@thaumic-cast/protocol';
 import { exponentialBackoff } from '../lib/backoff';
-
-const log = createLogger('AudioWorker');
+import {
+  type WorkerState,
+  type CustomMetrics,
+  createWorkerState,
+  resetFrameQueueState,
+  postToMain,
+  alignDown,
+  yieldMacrotask,
+  isWsBackpressured,
+  enqueueFrame,
+  flushFrameQueue,
+  flushQueuedFrames,
+  maybePostStats,
+  connectWebSocket,
+  handleCommonMessage,
+  cleanupSharedState,
+  BACKPRESSURE_BACKOFF_INITIAL_MS,
+  BACKPRESSURE_BACKOFF_MAX_MS,
+  QUALITY_BACKOFF_MAX_MS,
+  WAIT_TIMEOUT_MS,
+} from './worker-base';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Codec-Aware Frame Sizing
@@ -90,7 +102,7 @@ function frameSizeToMs(frameSizeSamples: number, sampleRate: number): number {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Constants
+// Worker-Specific Constants
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -100,24 +112,6 @@ function frameSizeToMs(frameSizeSamples: number, sampleRate: number): number {
  * layout, rendering, and GC, so we busy-poll within budget instead.
  */
 const PROCESS_BUDGET_MS = 4;
-
-/** Initial backpressure backoff delay (ms). */
-const BACKPRESSURE_BACKOFF_INITIAL_MS = 5;
-
-/** Maximum backpressure backoff delay for realtime mode (ms). */
-const BACKPRESSURE_BACKOFF_MAX_MS = 40;
-
-/** Maximum backpressure backoff delay for quality mode (ms). */
-const QUALITY_BACKOFF_MAX_MS = 50;
-
-/** Timeout for waiting on producer (ms). Triggers underflow if exceeded. 200ms = 20 frames of headroom. */
-const WAIT_TIMEOUT_MS = 200;
-
-/** Interval for posting diagnostic stats to main thread (ms). */
-const STATS_INTERVAL_MS = 2000;
-
-/** Heartbeat interval for WebSocket (ms). */
-const HEARTBEAT_INTERVAL_MS = 5000;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Underflow Ramp Constants
@@ -129,21 +123,15 @@ const HEARTBEAT_INTERVAL_MS = 5000;
  */
 const RAMP_MS = 3;
 
-/** WebSocket connection timeout (ms). */
-const WS_CONNECT_TIMEOUT_MS = 5000;
-
-/** Handshake timeout (ms). */
-const HANDSHAKE_TIMEOUT_MS = 5000;
-
 // ─────────────────────────────────────────────────────────────────────────────
-// Worker State
+// Shared Worker State
 // ─────────────────────────────────────────────────────────────────────────────
 
-// Streaming policy (derived from latencyMode)
-let policy: StreamingPolicy | null = null;
+const s: WorkerState = createWorkerState('AudioWorker');
 
-// Browser capture mode (no local audio pipeline — server captures via WASAPI)
-let browserCaptureMode = false;
+// ─────────────────────────────────────────────────────────────────────────────
+// Worker-Specific State
+// ─────────────────────────────────────────────────────────────────────────────
 
 // Ring buffer state
 let control: Int32Array | null = null;
@@ -157,20 +145,14 @@ let frameSizeSamples = 0;
 let frameBuffer: Float32Array | null = null;
 let frameOffset = 0;
 
-// Encoder and WebSocket
+// Encoder
 let encoder: AudioEncoder | null = null;
-let socket: WebSocket | null = null;
-let streamId: string | null = null;
-let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
 
-// Diagnostic counters
+// Diagnostic counters (worker-specific, reset per stats interval)
 let underflowCount = 0;
 let droppedFrameCount = 0;
 let wakeupCount = 0;
 let totalSamplesRead = 0;
-let lastStatsTime = 0;
-/** Last reported value of CTRL_DROPPED_SAMPLES for computing delta. */
-let lastProducerDroppedSamples = 0;
 
 // Bounded latency catch-up tracking
 /** Samples dropped by consumer catch-up logic this stats interval. */
@@ -203,53 +185,6 @@ let lastSamples: Float32Array | null = null;
 let rampSamples = 0;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Frame Queue for Quality Mode Backpressure Decoupling
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Queue of encoded frames waiting to be sent when WebSocket backpressure eases.
- * Only used in quality mode - realtime mode drops frames instead of queuing.
- */
-let frameQueue: Uint8Array[] = [];
-
-/**
- * Total bytes currently in frameQueue.
- * Tracked separately to avoid O(n) length calculation.
- */
-let frameQueueBytes = 0;
-
-/**
- * Maximum frame queue size in bytes (~30 seconds of audio).
- * At 48kHz/16-bit stereo PCM: ~5.76MB for 30s. With headroom: 8MB.
- */
-const FRAME_QUEUE_MAX_BYTES = 8 * 1024 * 1024;
-
-/**
- * Target frame queue size after overflow trimming.
- * Uses hysteresis ratio from streaming policy to prevent oscillation.
- */
-const FRAME_QUEUE_TARGET_BYTES = Math.floor(FRAME_QUEUE_MAX_BYTES * FRAME_QUEUE_HYSTERESIS_RATIO);
-
-// Producer drop detection
-/** Previous value of CTRL_DROPPED_SAMPLES for detecting new drops. */
-let prevProducerDroppedSamples = 0;
-
-/** Count of frames dropped from queue due to overflow (stats). */
-let frameQueueOverflowDrops = 0;
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Utilities
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Posts a message to the main thread.
- * @param message
- */
-function postToMain(message: WorkerOutboundMessage): void {
-  self.postMessage(message);
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Underflow Ramp Utilities
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -262,7 +197,7 @@ function postToMain(message: WorkerOutboundMessage): void {
  * @param buffer - Interleaved Float32 samples to modify in-place
  * @param channels - Number of audio channels (1 or 2)
  * @param rampLen - Number of interleaved samples to ramp (clamped to buffer length)
- * @param fadeIn - True for fade-in (0→1), false for fade-out (1→0)
+ * @param fadeIn - True for fade-in (0->1), false for fade-out (1->0)
  * @param startSamples - Per-channel starting values for fade-out (ignored for fade-in)
  */
 function applyRamp(
@@ -281,8 +216,8 @@ function applyRamp(
 
   for (let frame = 0; frame < frames; frame++) {
     // Linear ramp coefficient:
-    // Fade-in: 0→1 (first sample at silence, last at full amplitude)
-    // Fade-out: 1→0 (first sample at full amplitude, last at silence)
+    // Fade-in: 0->1 (first sample at silence, last at full amplitude)
+    // Fade-out: 1->0 (first sample at full amplitude, last at silence)
     const t = fadeIn ? frame / divisor : 1 - frame / divisor;
 
     for (let ch = 0; ch < channels; ch++) {
@@ -322,115 +257,8 @@ function captureLastSamples(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Frame Queue Management (Quality Mode)
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Adds an encoded frame to the queue.
- * If queue exceeds bounds, trims oldest frames to target size.
- *
- * @param frame - Encoded frame data to queue
- */
-function enqueueFrame(frame: Uint8Array): void {
-  frameQueue.push(frame);
-  frameQueueBytes += frame.byteLength;
-
-  if (frameQueueBytes > FRAME_QUEUE_MAX_BYTES) {
-    trimFrameQueue();
-  }
-}
-
-/**
- * Trims the frame queue to target size, dropping oldest frames.
- * Uses hysteresis (FRAME_QUEUE_HYSTERESIS_RATIO) to prevent oscillation.
- * Uses splice() once instead of shift() in loop for O(n) vs O(n²) performance.
- */
-function trimFrameQueue(): void {
-  // Count how many frames to drop
-  let droppedBytes = 0;
-  let droppedCount = 0;
-  let bytesToDrop = frameQueueBytes - FRAME_QUEUE_TARGET_BYTES;
-
-  while (droppedCount < frameQueue.length && bytesToDrop > 0) {
-    const frameBytes = frameQueue[droppedCount]!.byteLength;
-    droppedBytes += frameBytes;
-    bytesToDrop -= frameBytes;
-    droppedCount++;
-  }
-
-  if (droppedCount > 0) {
-    // Remove all at once - O(n) instead of O(n²)
-    frameQueue.splice(0, droppedCount);
-    frameQueueBytes -= droppedBytes;
-    frameQueueOverflowDrops += droppedCount;
-    log.warn(
-      `Frame queue overflow: dropped ${droppedCount} frames (${(droppedBytes / 1024).toFixed(1)}KB) ` +
-        `to maintain ~30s bound`,
-    );
-  }
-}
-
-/**
- * Attempts to flush queued frames to WebSocket.
- * Respects WebSocket backpressure - stops when buffer exceeds high water mark.
- * Uses splice() once at end instead of shift() per frame for O(n) vs O(n²) performance.
- *
- * @returns Number of frames sent
- */
-function flushFrameQueue(): number {
-  if (!socket || socket.readyState !== WebSocket.OPEN || !policy) {
-    return 0;
-  }
-
-  let sentCount = 0;
-  let sentBytes = 0;
-
-  // Send frames by index, then remove all at once
-  while (sentCount < frameQueue.length) {
-    // Check WebSocket backpressure before each send
-    if (socket.bufferedAmount >= policy.wsBufferHighWater) {
-      break;
-    }
-
-    const frame = frameQueue[sentCount]!;
-    socket.send(frame);
-    sentBytes += frame.byteLength;
-    sentCount++;
-  }
-
-  // Remove all sent frames at once - O(n) instead of O(n²)
-  if (sentCount > 0) {
-    frameQueue.splice(0, sentCount);
-    frameQueueBytes -= sentBytes;
-  }
-
-  return sentCount;
-}
-
-/**
- * Resets frame queue state to initial values.
- * Used during cleanup and initialization.
- */
-function resetFrameQueueState(): void {
-  frameQueue = [];
-  frameQueueBytes = 0;
-  frameQueueOverflowDrops = 0;
-  prevProducerDroppedSamples = 0;
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Bounded Latency Catch-up
 // ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Aligns a sample count down to the nearest frame boundary.
- * @param samples - Number of samples
- * @param frameSize - Frame size in samples
- * @returns Aligned sample count
- */
-function alignDown(samples: number, frameSize: number): number {
-  return Math.floor(samples / frameSize) * frameSize;
-}
 
 /**
  * Performs catch-up if the ring buffer has accumulated too much data.
@@ -446,10 +274,10 @@ function alignDown(samples: number, frameSize: number): number {
  * @returns The number of samples dropped, or 0 if no catch-up needed
  */
 function performCatchUpIfNeeded(): number {
-  if (!control || !encoder || !policy) return 0;
+  if (!control || !encoder || !s.policy) return 0;
 
   // Quality mode: catch-up is disabled
-  if (policy.catchUpMaxMs === null) return 0;
+  if (s.policy.catchUpMaxMs === null) return 0;
 
   const writeIdx = Atomics.load(control, CTRL_WRITE_IDX);
   const readIdx = Atomics.load(control, CTRL_READ_IDX);
@@ -484,7 +312,7 @@ function performCatchUpIfNeeded(): number {
 
   // Log the event
   const droppedMs = (totalDroppedSamples / (encoder.config.sampleRate * channels)) * 1000;
-  log.warn(`⏩ CATCH-UP: Dropped ${droppedMs.toFixed(0)}ms of audio to bound latency`);
+  s.log.warn(`CATCH-UP: Dropped ${droppedMs.toFixed(0)}ms of audio to bound latency`);
 
   return totalDroppedSamples;
 }
@@ -561,7 +389,13 @@ function readFromRingBuffer(): number {
  * transitioning to silence rather than abruptly stopping.
  */
 function handleUnderflowRamp(): void {
-  if (!frameBuffer || !encoder || !socket || socket.readyState !== WebSocket.OPEN || !lastSamples) {
+  if (
+    !frameBuffer ||
+    !encoder ||
+    !s.socket ||
+    s.socket.readyState !== WebSocket.OPEN ||
+    !lastSamples
+  ) {
     return;
   }
 
@@ -604,14 +438,14 @@ function handleUnderflowRamp(): void {
   // Encode and send (skip backpressure check for underflow frame)
   const encoded = encoder.encode(frameBuffer);
   if (encoded) {
-    socket.send(encoded);
+    s.socket.send(encoded);
   }
 
   // Reset for next frame
   frameOffset = 0;
   needsRampIn = true;
 
-  log.debug('Flushed underflow frame with ramp-down');
+  s.log.debug('Flushed underflow frame with ramp-down');
 }
 
 /**
@@ -627,15 +461,15 @@ function handleUnderflowRamp(): void {
  */
 function flushFrameIfReady(): void {
   if (!frameBuffer || frameOffset < frameSizeSamples) return;
-  if (!encoder || !socket || socket.readyState !== WebSocket.OPEN || !policy) return;
+  if (!encoder || !s.socket || s.socket.readyState !== WebSocket.OPEN || !s.policy) return;
 
   const channels = encoder.config.channels;
 
   // Encoder backpressure blocks both modes (can't bypass encoder)
-  const encoderBackpressured = encoder.encodeQueueSize >= policy.maxEncodeQueue;
+  const encoderBackpressured = encoder.encodeQueueSize >= s.policy.maxEncodeQueue;
 
   if (encoderBackpressured) {
-    if (policy.dropOnBackpressure) {
+    if (s.policy.dropOnBackpressure) {
       // Realtime mode: drop frame to maintain timing
       droppedFrameCount++;
       encoder.advanceTimestamp(frameSizeSamples / channels);
@@ -650,7 +484,7 @@ function flushFrameIfReady(): void {
   if (needsRampIn && rampSamples >= channels) {
     applyRamp(frameBuffer, channels, rampSamples, true);
     needsRampIn = false;
-    log.debug('Applied fade-in ramp after discontinuity');
+    s.log.debug('Applied fade-in ramp after discontinuity');
   }
 
   // Encode the frame
@@ -662,312 +496,56 @@ function flushFrameIfReady(): void {
   if (!encoded) return;
 
   // WebSocket backpressure handling differs by mode
-  const wsBackpressured = socket.bufferedAmount >= policy.wsBufferHighWater;
+  const wsBackpressured = isWsBackpressured(s);
 
   if (wsBackpressured) {
-    if (policy.dropOnBackpressure) {
+    if (s.policy.dropOnBackpressure) {
       // Realtime mode: drop the encoded frame
       droppedFrameCount++;
     } else {
       // Quality mode: queue the frame instead of blocking ring buffer drain
-      enqueueFrame(encoded);
+      enqueueFrame(s, encoded);
     }
     return;
   }
 
   // No backpressure: send directly
-  socket.send(encoded);
+  s.socket.send(encoded);
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Custom Metrics
+// ─────────────────────────────────────────────────────────────────────────────
+
 /**
- * Posts diagnostic stats to main thread.
+ * Returns worker-specific metrics for stats reporting.
  */
-function maybePostStats(): void {
-  if (!control) return;
-
-  const now = performance.now();
-  if (now - lastStatsTime < STATS_INTERVAL_MS) return;
-
-  // Compute producer dropped samples delta
-  const totalDropped = Atomics.load(control, CTRL_DROPPED_SAMPLES);
-  const producerDroppedSamples = (totalDropped - lastProducerDroppedSamples) >>> 0;
-  lastProducerDroppedSamples = totalDropped;
-
-  const avgSamplesPerWake = wakeupCount > 0 ? totalSamplesRead / wakeupCount : 0;
-
-  postToMain({
-    type: 'STATS',
+function getCustomMetrics(): CustomMetrics {
+  return {
     underflows: underflowCount,
-    producerDroppedSamples,
     consumerDroppedFrames: droppedFrameCount,
     catchUpDroppedSamples,
     backpressureCycles,
     wakeups: wakeupCount,
-    avgSamplesPerWake,
+    avgSamplesPerWake: wakeupCount > 0 ? totalSamplesRead / wakeupCount : 0,
     encodeQueueSize: encoder?.encodeQueueSize ?? 0,
-    wsBufferedAmount: socket?.bufferedAmount ?? 0,
-    frameQueueSize: frameQueue.length,
-    frameQueueBytes,
-    frameQueueOverflowDrops,
-  });
+  };
+}
 
-  // Reset interval counters
+/**
+ * Resets worker-specific interval counters after stats are posted.
+ */
+function resetCustomCounters(): void {
   underflowCount = 0;
   droppedFrameCount = 0;
   catchUpDroppedSamples = 0;
   backpressureCycles = 0;
-  frameQueueOverflowDrops = 0;
   wakeupCount = 0;
   totalSamplesRead = 0;
-  lastStatsTime = now;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// WebSocket Management
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Connects to the WebSocket and performs handshake.
- * @param wsUrl - The WebSocket URL to connect to
- * @param encoderConfig - The encoder configuration for the stream
- * @returns A promise resolving to the stream ID
- */
-/** Handshake message to send on WS connect. */
-interface HandshakeMessage {
-  type: string;
-  payload: Record<string, unknown>;
-}
-
-/**
- *
- * @param wsUrl
- * @param handshake
- */
-async function connectWebSocket(wsUrl: string, handshake: HandshakeMessage): Promise<string> {
-  return new Promise((resolve, reject) => {
-    log.info(`Connecting to WebSocket: ${wsUrl}`);
-
-    const ws = new WebSocket(wsUrl);
-    ws.binaryType = 'arraybuffer';
-    socket = ws;
-
-    const connectTimeout = setTimeout(() => {
-      ws.close();
-      reject(new Error('WebSocket connection timeout'));
-    }, WS_CONNECT_TIMEOUT_MS);
-
-    ws.onopen = () => {
-      clearTimeout(connectTimeout);
-      log.info('WebSocket connected, sending handshake...');
-
-      // Send handshake
-      ws.send(JSON.stringify(handshake));
-
-      // Wait for handshake response
-      const handshakeTimeout = setTimeout(() => {
-        ws.close();
-        reject(new Error('Handshake timeout'));
-      }, HANDSHAKE_TIMEOUT_MS);
-
-      // Handle clean close during handshake (overwritten by handleWsClose on success)
-      ws.onclose = (event: CloseEvent) => {
-        clearTimeout(handshakeTimeout);
-        reject(
-          new Error(`WebSocket closed during handshake: ${event.reason || `Code ${event.code}`}`),
-        );
-      };
-
-      const handshakeHandler = (event: MessageEvent) => {
-        if (typeof event.data !== 'string') return;
-
-        try {
-          const raw = JSON.parse(event.data);
-
-          // Skip broadcast events
-          if ('category' in raw || raw.type === 'INITIAL_STATE') return;
-
-          const parsed = WsMessageSchema.safeParse(raw);
-          if (!parsed.success) return;
-
-          const message = parsed.data;
-
-          if (message.type === 'HANDSHAKE_ACK') {
-            clearTimeout(handshakeTimeout);
-            ws.removeEventListener('message', handshakeHandler);
-            streamId = message.payload.streamId;
-            log.info(`Handshake complete, streamId: ${streamId}`);
-
-            // Start heartbeat
-            startHeartbeat();
-
-            // Set up persistent message handler
-            ws.onmessage = handleWsMessage;
-            ws.onclose = handleWsClose;
-            ws.onerror = handleWsError;
-
-            resolve(message.payload.streamId);
-          } else if (message.type === 'ERROR') {
-            clearTimeout(handshakeTimeout);
-            ws.removeEventListener('message', handshakeHandler);
-            reject(new Error(message.payload.message));
-          }
-        } catch {
-          // Ignore parse errors during handshake
-        }
-      };
-
-      ws.addEventListener('message', handshakeHandler);
-    };
-
-    ws.onerror = () => {
-      clearTimeout(connectTimeout);
-      reject(new Error('WebSocket connection error'));
-    };
-  });
-}
-
-/**
- * Handles incoming WebSocket messages.
- * @param event
- */
-function handleWsMessage(event: MessageEvent): void {
-  if (typeof event.data !== 'string') return;
-
-  try {
-    const raw = JSON.parse(event.data);
-
-    // Skip broadcast events
-    if ('category' in raw || raw.type === 'INITIAL_STATE') return;
-
-    const parsed = WsMessageSchema.safeParse(raw);
-    if (!parsed.success) return;
-
-    const message: WsMessage = parsed.data;
-
-    switch (message.type) {
-      case 'HEARTBEAT_ACK':
-        // Heartbeat acknowledged, connection is alive
-        break;
-
-      case 'STREAM_READY':
-        log.info(`Stream ready with ${message.payload.bufferSize} frames buffered`);
-        postToMain({
-          type: 'STREAM_READY',
-          bufferSize: message.payload.bufferSize,
-        });
-        break;
-
-      case 'PLAYBACK_STARTED':
-        log.info(`Playback started on ${message.payload.speakerIp}`);
-        postToMain({
-          type: 'PLAYBACK_STARTED',
-          speakerIp: message.payload.speakerIp,
-          streamUrl: message.payload.streamUrl,
-        });
-        break;
-
-      case 'PLAYBACK_RESULTS': {
-        const results = message.payload.results;
-        const successful = results.filter((r) => r.success).length;
-        log.info(`Playback results: ${successful}/${results.length} speakers started`);
-        postToMain({
-          type: 'PLAYBACK_RESULTS',
-          results,
-        });
-        break;
-      }
-
-      case 'PLAYBACK_ERROR':
-        log.error(`Playback error: ${message.payload.message}`);
-        postToMain({
-          type: 'PLAYBACK_ERROR',
-          message: message.payload.message,
-        });
-        break;
-
-      case 'ERROR':
-        log.error(`Server error: ${message.payload.message}`);
-        postToMain({
-          type: 'ERROR',
-          message: message.payload.message,
-        });
-        break;
-
-      case 'BROWSER_CAPTURE_ERROR':
-        log.error(`Browser capture error: ${message.payload.error} (${message.payload.reason})`);
-        postToMain({
-          type: 'BROWSER_CAPTURE_ERROR',
-          error: message.payload.error,
-          reason: message.payload.reason,
-        });
-        break;
-
-      default:
-        // Ignore other message types
-        break;
-    }
-  } catch {
-    // Ignore parse errors
-  }
-}
-
-/**
- * Handles WebSocket close.
- * @param event
- */
-function handleWsClose(event: CloseEvent): void {
-  log.warn(`WebSocket closed: ${event.code} ${event.reason}`);
-  stopHeartbeat();
-  postToMain({
-    type: 'DISCONNECTED',
-    reason: event.reason || `Code ${event.code}`,
-  });
-}
-
-/**
- * Handles WebSocket errors.
- */
-function handleWsError(): void {
-  log.error('WebSocket error');
-}
-
-/**
- * Starts the heartbeat timer.
- */
-function startHeartbeat(): void {
-  stopHeartbeat();
-  heartbeatInterval = setInterval(() => {
-    if (socket?.readyState === WebSocket.OPEN) {
-      socket.send(JSON.stringify({ type: 'HEARTBEAT' }));
-    }
-  }, HEARTBEAT_INTERVAL_MS);
-}
-
-/**
- * Stops the heartbeat timer.
- */
-function stopHeartbeat(): void {
-  if (heartbeatInterval) {
-    clearInterval(heartbeatInterval);
-    heartbeatInterval = null;
-  }
-}
-
-/**
- * Sends a message over WebSocket.
- * @param message - The message object to send
- * @returns True if the message was sent, false otherwise
- */
-function sendWsMessage(message: object): boolean {
-  if (!socket || socket.readyState !== WebSocket.OPEN) {
-    return false;
-  }
-  socket.send(JSON.stringify(message));
-  return true;
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Flow Control Helpers
+// Flow Control
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -976,10 +554,10 @@ function sendWsMessage(message: object): boolean {
  * @returns True if encoder queue or WebSocket buffer is overloaded
  */
 function isBackpressured(): boolean {
-  if (!policy) return false;
+  if (!s.policy) return false;
   return (
-    (encoder?.encodeQueueSize ?? 0) >= policy.maxEncodeQueue ||
-    (socket?.bufferedAmount ?? 0) >= policy.wsBufferHighWater
+    (encoder?.encodeQueueSize ?? 0) >= s.policy.maxEncodeQueue ||
+    (s.socket?.bufferedAmount ?? 0) >= s.policy.wsBufferHighWater
   );
 }
 
@@ -989,36 +567,7 @@ function isBackpressured(): boolean {
  * @returns True if encoder queue is at or above threshold
  */
 function isEncoderBackpressured(): boolean {
-  return encoder !== null && encoder.encodeQueueSize >= (policy?.maxEncodeQueue ?? 16);
-}
-
-/**
- * Reusable MessageChannel for zero-delay yields.
- * MessageChannel posts directly to the task queue with sub-millisecond latency,
- * unlike setTimeout(0) which has minimum 1-4ms delay due to browser throttling.
- */
-const yieldChannel = new MessageChannel();
-let yieldResolve: (() => void) | null = null;
-yieldChannel.port2.onmessage = () => {
-  yieldResolve?.();
-  yieldResolve = null;
-};
-
-/**
- * Yields to the macrotask queue.
- * Unlike microtasks (Promise.resolve), this actually yields CPU time.
- * @param ms - Milliseconds to wait (use 0 to just yield without delay)
- * @returns A promise that resolves after the delay
- */
-function yieldMacrotask(ms: number): Promise<void> {
-  if (ms === 0) {
-    // Use MessageChannel for zero-delay yield - faster than setTimeout(0)
-    return new Promise((resolve) => {
-      yieldResolve = resolve;
-      yieldChannel.port1.postMessage(null);
-    });
-  }
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return encoder !== null && encoder.encodeQueueSize >= (s.policy?.maxEncodeQueue ?? 16);
 }
 
 /**
@@ -1039,7 +588,7 @@ function drainWithTimeBudget(): number {
     // Check backpressure before processing each frame
     // Quality mode: only block on encoder (WebSocket handled by frame queue)
     // Realtime mode: block on both encoder and WebSocket
-    if (policy?.dropOnBackpressure) {
+    if (s.policy?.dropOnBackpressure) {
       if (isBackpressured()) break;
     } else {
       // Quality mode: only check encoder backpressure
@@ -1088,8 +637,8 @@ function drainWithTimeBudget(): number {
 async function consumeLoop(): Promise<void> {
   if (!control) return;
 
-  lastStatsTime = performance.now();
-  lastProducerDroppedSamples = Atomics.load(control, CTRL_DROPPED_SAMPLES);
+  s.lastStatsTime = performance.now();
+  s.prevProducerDroppedSamples = Atomics.load(control, CTRL_DROPPED_SAMPLES);
 
   while (running) {
     // BOUNDED LATENCY (realtime mode only): Check if buffer has grown too large
@@ -1099,32 +648,34 @@ async function consumeLoop(): Promise<void> {
     // DETECT PRODUCER DROPS: Check if AudioWorklet dropped samples
     // This happens when ring buffer fills faster than we drain (rare in quality mode with frame queue)
     const currentDropped = Atomics.load(control, CTRL_DROPPED_SAMPLES);
-    if (currentDropped !== prevProducerDroppedSamples) {
-      const dropDelta = (currentDropped - prevProducerDroppedSamples) >>> 0;
+    if (currentDropped !== s.prevProducerDroppedSamples) {
+      const dropDelta = (currentDropped - s.prevProducerDroppedSamples) >>> 0;
       if (dropDelta > 0) {
-        log.warn(`Producer dropped ${dropDelta} samples - marking for ramp-in`);
+        s.log.warn(`Producer dropped ${dropDelta} samples - marking for ramp-in`);
         needsRampIn = true;
       }
-      prevProducerDroppedSamples = currentDropped;
+      s.prevProducerDroppedSamples = currentDropped;
     }
 
     // QUALITY MODE: Flush any queued frames before checking backpressure
-    if (!policy?.dropOnBackpressure && frameQueue.length > 0) {
-      const flushed = flushFrameQueue();
+    if (!s.policy?.dropOnBackpressure && s.frameQueue.length > 0) {
+      const flushed = flushFrameQueue(s);
       if (flushed > 0) {
-        log.debug(`Flushed ${flushed} queued frames`);
+        s.log.debug(`Flushed ${flushed} queued frames`);
       }
     }
 
     // BACKPRESSURE HANDLING: Differs by mode
     // Realtime mode: check encoder + WebSocket backpressure
     // Quality mode: only check encoder (WebSocket handled by frame queue)
-    const shouldBackoff = policy?.dropOnBackpressure ? isBackpressured() : isEncoderBackpressured();
+    const shouldBackoff = s.policy?.dropOnBackpressure
+      ? isBackpressured()
+      : isEncoderBackpressured();
 
     if (shouldBackoff) {
       backpressureCycles++;
       consecutiveBackpressureCycles++;
-      const maxMs = policy?.dropOnBackpressure
+      const maxMs = s.policy?.dropOnBackpressure
         ? BACKPRESSURE_BACKOFF_MAX_MS
         : QUALITY_BACKOFF_MAX_MS;
       const backoffMs = exponentialBackoff(
@@ -1132,7 +683,7 @@ async function consumeLoop(): Promise<void> {
         BACKPRESSURE_BACKOFF_INITIAL_MS,
         maxMs,
       );
-      maybePostStats();
+      maybePostStats(s, control, bufferSize, getCustomMetrics, resetCustomCounters);
       await yieldMacrotask(backoffMs);
       continue;
     }
@@ -1171,7 +722,7 @@ async function consumeLoop(): Promise<void> {
       }
     }
 
-    maybePostStats();
+    maybePostStats(s, control, bufferSize, getCustomMetrics, resetCustomCounters);
 
     // Check if buffer is empty
     const write = Atomics.load(control, CTRL_WRITE_IDX);
@@ -1198,44 +749,38 @@ async function consumeLoop(): Promise<void> {
       }
       // 'ok' = notified, 'not-equal' = value changed before wait
     }
-    // Producer notified us on empty→non-empty transition
+    // Producer notified us on empty->non-empty transition
   }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cleanup
+// ─────────────────────────────────────────────────────────────────────────────
 
 /**
  * Flushes any remaining samples, encoder buffer, and queued frames.
  */
 function flushRemaining(): void {
   // Flush partial frame
-  if (frameBuffer && frameOffset > 0 && encoder && socket?.readyState === WebSocket.OPEN) {
+  if (frameBuffer && frameOffset > 0 && encoder && s.socket?.readyState === WebSocket.OPEN) {
     // subarray() returns a view, no copy needed
     const encoded = encoder.encode(frameBuffer.subarray(0, frameOffset));
     if (encoded) {
-      socket.send(encoded);
+      s.socket.send(encoded);
     }
     frameOffset = 0;
   }
 
   // Flush encoder buffer
-  if (encoder && socket?.readyState === WebSocket.OPEN) {
+  if (encoder && s.socket?.readyState === WebSocket.OPEN) {
     const final = encoder.flush();
     if (final) {
-      socket.send(final);
+      s.socket.send(final);
     }
   }
 
   // Flush queued frames (quality mode may have buffered frames during backpressure)
-  if (frameQueue.length > 0 && socket?.readyState === WebSocket.OPEN) {
-    const flushedCount = frameQueue.length;
-    const flushedBytes = frameQueueBytes;
-    // Send all without backpressure check - we're shutting down
-    for (const frame of frameQueue) {
-      socket.send(frame);
-    }
-    log.info(
-      `Flushed ${flushedCount} queued frames (${(flushedBytes / 1024).toFixed(1)}KB) on cleanup`,
-    );
-  }
+  flushQueuedFrames(s);
 }
 
 /**
@@ -1244,46 +789,26 @@ function flushRemaining(): void {
 function cleanup(): void {
   running = false;
 
-  if (!browserCaptureMode) {
+  if (!s.browserCaptureMode) {
     flushRemaining();
   }
 
-  stopHeartbeat();
-
-  if (!browserCaptureMode && encoder) {
+  if (!s.browserCaptureMode && encoder) {
     encoder.close();
     encoder = null;
   }
 
-  if (socket) {
-    // Send stop message before closing in browser capture mode
-    if (browserCaptureMode && socket.readyState === WebSocket.OPEN) {
-      try {
-        socket.send(JSON.stringify({ type: 'STOP_BROWSER_CAPTURE' }));
-      } catch {
-        /* ignore send errors during shutdown */
-      }
-    }
-    socket.onopen = null;
-    socket.onclose = null;
-    socket.onerror = null;
-    socket.onmessage = null;
-    socket.close();
-    socket = null;
-  }
+  cleanupSharedState(s);
 
-  streamId = null;
-  policy = null;
-
-  if (!browserCaptureMode) {
+  if (!s.browserCaptureMode) {
     // Reset audio-specific state
     needsRampIn = false;
     lastSamples = null;
     rampSamples = 0;
-    resetFrameQueueState();
+    resetFrameQueueState(s);
   }
 
-  browserCaptureMode = false;
+  s.browserCaptureMode = false;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1292,6 +817,11 @@ function cleanup(): void {
 
 self.onmessage = async (event: MessageEvent<WorkerInboundMessage>) => {
   const msg = event.data;
+
+  // Delegate common messages (STOP, START_PLAYBACK, METADATA_UPDATE)
+  if (handleCommonMessage(s, msg, cleanup)) {
+    return;
+  }
 
   if (msg.type === 'INIT') {
     const {
@@ -1305,6 +835,11 @@ self.onmessage = async (event: MessageEvent<WorkerInboundMessage>) => {
     } = msg;
 
     try {
+      // Validate SAB fields are present (now optional in WorkerInitMessage for MSTP path)
+      if (!sab || size === undefined || mask === undefined || headerSize === undefined) {
+        throw new Error('SAB path requires sab, bufferSize, bufferMask, and headerSize');
+      }
+
       if ((size & (size - 1)) !== 0 || mask !== size - 1) {
         throw new Error('Invalid ring buffer configuration (size must be power of two)');
       }
@@ -1343,15 +878,15 @@ self.onmessage = async (event: MessageEvent<WorkerInboundMessage>) => {
         frameSizeSamples: optimalFrameSamples,
       };
 
-      log.info(
+      s.log.info(
         `Frame size: ${optimalFrameSamples} samples (${framePeriodMs.toFixed(1)}ms) for ${encoderConfig.codec}`,
       );
 
       // Initialize streaming policy from latency mode
-      policy = getStreamingPolicy(encoderConfig.latencyMode);
-      log.info(
+      s.policy = getStreamingPolicy(encoderConfig.latencyMode);
+      s.log.info(
         `Streaming policy: ${encoderConfig.latencyMode} mode ` +
-          `(catchUp=${policy.catchUpMaxMs ?? 'disabled'}, dropOnBackpressure=${policy.dropOnBackpressure})`,
+          `(catchUp=${s.policy.catchUpMaxMs ?? 'disabled'}, dropOnBackpressure=${s.policy.dropOnBackpressure})`,
       );
 
       // Reset state
@@ -1363,38 +898,41 @@ self.onmessage = async (event: MessageEvent<WorkerInboundMessage>) => {
       nextFrameDueTime = 0;
       wakeupCount = 0;
       totalSamplesRead = 0;
-      lastProducerDroppedSamples = 0;
+      s.prevProducerDroppedSamples = 0;
 
-      resetFrameQueueState();
+      resetFrameQueueState(s);
 
       // Compute catch-up thresholds based on policy and sample rate
       // These define the bounded latency window (only used in realtime mode)
       const samplesPerMs = (sampleRate * encoderConfig.channels) / 1000;
-      catchUpTargetSamples = Math.floor(policy.catchUpTargetMs * samplesPerMs);
+      catchUpTargetSamples = Math.floor(s.policy.catchUpTargetMs * samplesPerMs);
       catchUpMaxSamples =
-        policy.catchUpMaxMs !== null ? Math.floor(policy.catchUpMaxMs * samplesPerMs) : Infinity; // Quality mode: effectively disable catch-up
+        s.policy.catchUpMaxMs !== null
+          ? Math.floor(s.policy.catchUpMaxMs * samplesPerMs)
+          : Infinity; // Quality mode: effectively disable catch-up
 
       // Create encoder
-      log.info(`Creating encoder: ${encoderConfig.codec} @ ${encoderConfig.bitrate}kbps`);
+      s.log.info(`Creating encoder: ${encoderConfig.codec} @ ${encoderConfig.bitrate}kbps`);
       encoder = await createEncoder(configWithFrameSize);
 
       // Connect WebSocket (sends frame size to server in handshake)
-      const id = await connectWebSocket(wsUrl, {
+      const id = await connectWebSocket(s, wsUrl, {
         type: 'HANDSHAKE',
         payload: { encoderConfig: configWithFrameSize },
       });
 
       running = true;
+      s.streamStartTime = performance.now();
       postToMain({ type: 'CONNECTED', streamId: id });
 
       // Start consumption loop
       consumeLoop().catch((err) => {
-        log.error('consumeLoop error:', err);
+        s.log.error('consumeLoop error:', err);
         postToMain({ type: 'ERROR', message: String(err) });
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      log.error('Initialization failed:', message);
+      s.log.error('Initialization failed:', message);
       postToMain({ type: 'ERROR', message });
       cleanup();
     }
@@ -1403,42 +941,24 @@ self.onmessage = async (event: MessageEvent<WorkerInboundMessage>) => {
   if (msg.type === 'INIT_BROWSER_CAPTURE') {
     const { wsUrl, encoderConfig, browserName } = msg;
     try {
-      browserCaptureMode = true;
+      s.browserCaptureMode = true;
 
-      // No ring buffer, no encoder, no consumeLoop —
+      // No ring buffer, no encoder, no consumeLoop --
       // server captures audio via WASAPI, Worker just manages WS lifecycle
-      const id = await connectWebSocket(wsUrl, {
+      const id = await connectWebSocket(s, wsUrl, {
         type: 'START_BROWSER_CAPTURE',
         payload: { browserName: browserName ?? null, encoderConfig },
       });
 
       running = true;
+      s.streamStartTime = performance.now();
       postToMain({ type: 'CONNECTED', streamId: id });
-      // Worker is now idle — WS message handler + heartbeat do all the work
+      // Worker is now idle -- WS message handler + heartbeat do all the work
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      log.error('Browser capture init failed:', message);
+      s.log.error('Browser capture init failed:', message);
       postToMain({ type: 'ERROR', message });
       cleanup();
     }
-  }
-
-  if (msg.type === 'STOP') {
-    cleanup();
-  }
-
-  if (msg.type === 'START_PLAYBACK') {
-    const { speakerIps, metadata, syncSpeakers = false, videoSyncEnabled } = msg;
-    sendWsMessage({
-      type: 'START_PLAYBACK',
-      payload: { speakerIps, metadata, syncSpeakers, videoSyncEnabled },
-    });
-  }
-
-  if (msg.type === 'METADATA_UPDATE') {
-    sendWsMessage({
-      type: 'METADATA_UPDATE',
-      payload: msg.metadata,
-    });
   }
 };

--- a/apps/extension/src/offscreen/audio-relay.worker.ts
+++ b/apps/extension/src/offscreen/audio-relay.worker.ts
@@ -48,9 +48,11 @@ let ch0Temp: Float32Array | null = null;
 let ch1Temp: Float32Array | null = null;
 let maxFrameSamples = 0;
 
-// Int16 accumulator. accumView is a persistent Uint8Array over accum.buffer
-// (refreshed on grow) used for zero-copy sends: WebSocket.send() copies the
-// bytes synchronously, so the backing buffer is safe to reuse next frame.
+// Int16 accumulator. accumView is a persistent Uint8Array over the same
+// backing ArrayBuffer, used for zero-copy sends: WebSocket.send() copies
+// the bytes synchronously, so the backing buffer is safe to reuse next frame.
+// Buffer is owned explicitly so both views share an ArrayBuffer (not SharedArrayBuffer).
+let accumBuffer: ArrayBuffer | null = null;
 let accum: Int16Array | null = null;
 let accumOffset = 0;
 let accumView: Uint8Array<ArrayBuffer> | null = null;
@@ -80,24 +82,21 @@ function ensureTempBuffers(needed: number): void {
   s.log.info(`Grew temp buffers to ${needed} samples/channel`);
 }
 
-/** Rebuilds the persistent Uint8Array view over `accum.buffer` after an allocation change. */
-function refreshAccumView(): void {
-  if (!accum) return;
-  // accum is allocated via `new Int16Array(number)`, so buffer is an ArrayBuffer
-  accumView = new Uint8Array(accum.buffer as ArrayBuffer, accum.byteOffset, accum.byteLength);
-}
-
 /**
- * Doubles the accumulator capacity (or grows to `needed`, whichever is larger) and refreshes the view.
+ * Doubles the accumulator capacity (or grows to `needed`, whichever is larger).
+ * Allocates a fresh ArrayBuffer and rebuilds both the Int16 and Uint8 views
+ * over it so they stay aliased.
  * @param needed
  */
 function growAccum(needed: number): void {
   if (!accum) return;
   const newSize = Math.max(accum.length * 2, needed);
-  const grown = new Int16Array(newSize);
+  const newBuffer = new ArrayBuffer(newSize * Int16Array.BYTES_PER_ELEMENT);
+  const grown = new Int16Array(newBuffer);
   grown.set(accum.subarray(0, accumOffset));
+  accumBuffer = newBuffer;
   accum = grown;
-  refreshAccumView();
+  accumView = new Uint8Array(newBuffer);
   s.log.info(`Grew frame accumulator to ${newSize} samples`);
 }
 
@@ -310,6 +309,7 @@ function cleanup(): void {
 
   ch0Temp = null;
   ch1Temp = null;
+  accumBuffer = null;
   accum = null;
   accumOffset = 0;
   accumView = null;
@@ -364,9 +364,10 @@ self.onmessage = async (event: MessageEvent<WorkerInboundMessage>) => {
       ch1Temp = new Float32Array(maxFrameSamples);
 
       // 4x frame headroom for variable AudioData sizes
-      accum = new Int16Array(frameSizeInterleaved * 4);
+      accumBuffer = new ArrayBuffer(frameSizeInterleaved * 4 * Int16Array.BYTES_PER_ELEMENT);
+      accum = new Int16Array(accumBuffer);
       accumOffset = 0;
-      refreshAccumView();
+      accumView = new Uint8Array(accumBuffer);
 
       audioReader = msg.readable.getReader();
 

--- a/apps/extension/src/offscreen/audio-relay.worker.ts
+++ b/apps/extension/src/offscreen/audio-relay.worker.ts
@@ -1,0 +1,397 @@
+/**
+ * Audio Relay Worker (MSTP path).
+ *
+ * Reads AudioData frames from a transferred ReadableStream, converts
+ * f32-planar → interleaved Int16 with TPDF dither, and sends fixed-size
+ * frames over WebSocket. Bypasses AudioContext to avoid the clock-domain
+ * crossing that causes zero-filled blocks (crackling) in the SAB path.
+ */
+
+import {
+  type WorkerState,
+  type CustomMetrics,
+  createWorkerState,
+  connectWebSocket,
+  maybePostStats,
+  handleCommonMessage,
+  cleanupSharedState,
+  flushQueuedFrames,
+  resetStatsCounters,
+  resetFrameQueueState,
+  postToMain,
+  yieldMacrotask,
+  enqueueFrame,
+  flushFrameQueue,
+  isWsBackpressured,
+  BACKPRESSURE_BACKOFF_INITIAL_MS,
+  BACKPRESSURE_BACKOFF_MAX_MS,
+  QUALITY_BACKOFF_MAX_MS,
+  FRAME_QUEUE_MAX_BYTES,
+} from './worker-base';
+import {
+  getStreamingPolicy,
+  tpdfDither,
+  INT16_MAX,
+  type EncoderConfig,
+} from '@thaumic-cast/protocol';
+import type { WorkerInboundMessage } from './worker-messages';
+import { exponentialBackoff } from '../lib/backoff';
+
+const s: WorkerState = createWorkerState('AudioRelayWorker');
+
+let running = false;
+let frameSizeInterleaved = 0;
+let audioReader: ReadableStreamDefaultReader<AudioData> | null = null;
+let channels = 2;
+
+let ch0Temp: Float32Array | null = null;
+let ch1Temp: Float32Array | null = null;
+let maxFrameSamples = 0;
+
+// Int16 accumulator. accumView is a persistent Uint8Array over accum.buffer
+// (refreshed on grow) used for zero-copy sends: WebSocket.send() copies the
+// bytes synchronously, so the backing buffer is safe to reuse next frame.
+let accum: Int16Array | null = null;
+let accumOffset = 0;
+let accumView: Uint8Array | null = null;
+
+// Gaps in AudioData timestamps represent clock reporting jitter, NOT missing
+// audio — the capture device delivers continuous samples.
+let expectedNextTimestamp = -1;
+let loggedFirstFrame = false;
+
+let gapCount = 0;
+let gapDurationUs = 0;
+let wakeupCount = 0;
+let totalSamplesRead = 0;
+let droppedFrameCount = 0;
+let backpressureCycles = 0;
+let consecutiveBackpressureCycles = 0;
+
+/**
+ * Grows per-channel f32 extraction buffers if an AudioData delivers more samples than seen before.
+ * @param needed
+ */
+function ensureTempBuffers(needed: number): void {
+  if (needed <= maxFrameSamples) return;
+  maxFrameSamples = needed;
+  ch0Temp = new Float32Array(needed);
+  ch1Temp = new Float32Array(needed);
+  s.log.info(`Grew temp buffers to ${needed} samples/channel`);
+}
+
+/** Rebuilds the persistent Uint8Array view over `accum.buffer` after an allocation change. */
+function refreshAccumView(): void {
+  if (!accum) return;
+  // accum is allocated via `new Int16Array(number)`, so buffer is an ArrayBuffer
+  accumView = new Uint8Array(accum.buffer as ArrayBuffer, accum.byteOffset, accum.byteLength);
+}
+
+/**
+ * Doubles the accumulator capacity (or grows to `needed`, whichever is larger) and refreshes the view.
+ * @param needed
+ */
+function growAccum(needed: number): void {
+  if (!accum) return;
+  const newSize = Math.max(accum.length * 2, needed);
+  const grown = new Int16Array(newSize);
+  grown.set(accum.subarray(0, accumOffset));
+  accum = grown;
+  refreshAccumView();
+  s.log.info(`Grew frame accumulator to ${newSize} samples`);
+}
+
+/**
+ * Fused: interleave + NaN-safe clamp to [-1, 1] + TPDF dither + Int16 saturate,
+ * written directly into the accumulator. Emits complete frames as they fill.
+ * @param srcCh0
+ * @param srcCh1
+ * @param count
+ */
+function emitFloat32Samples(
+  srcCh0: Float32Array,
+  srcCh1: Float32Array | null,
+  count: number,
+): void {
+  if (!accum || !accumView) return;
+
+  const interleavedCount = count * channels;
+  if (accumOffset + interleavedCount > accum.length) {
+    growAccum(accumOffset + interleavedCount);
+  }
+
+  let dst = accumOffset;
+  if (channels === 1) {
+    for (let i = 0; i < count; i++) {
+      const l = srcCh0[i]!;
+      // NaN-safe clamp: NaN comparisons return false, so NaN → 0
+      const cl = l >= -1 ? (l <= 1 ? l : 1) : l === l ? -1 : 0;
+      let ql = Math.round(cl * INT16_MAX + tpdfDither());
+      if (ql < -32768) ql = -32768;
+      else if (ql > 32767) ql = 32767;
+      accum[dst++] = ql;
+    }
+  } else {
+    for (let i = 0; i < count; i++) {
+      const l = srcCh0[i]!;
+      const r = srcCh1 ? srcCh1[i]! : l;
+      const cl = l >= -1 ? (l <= 1 ? l : 1) : l === l ? -1 : 0;
+      const cr = r >= -1 ? (r <= 1 ? r : 1) : r === r ? -1 : 0;
+      let ql = Math.round(cl * INT16_MAX + tpdfDither());
+      let qr = Math.round(cr * INT16_MAX + tpdfDither());
+      if (ql < -32768) ql = -32768;
+      else if (ql > 32767) ql = 32767;
+      if (qr < -32768) qr = -32768;
+      else if (qr > 32767) qr = 32767;
+      accum[dst++] = ql;
+      accum[dst++] = qr;
+    }
+  }
+  accumOffset = dst;
+
+  const frameBytes = frameSizeInterleaved * Int16Array.BYTES_PER_ELEMENT;
+  while (accumOffset >= frameSizeInterleaved) {
+    sendOrQueue(accumView.subarray(0, frameBytes));
+    accumOffset -= frameSizeInterleaved;
+    if (accumOffset > 0) {
+      accum.copyWithin(0, frameSizeInterleaved, frameSizeInterleaved + accumOffset);
+    }
+  }
+}
+
+/**
+ * Sends directly from the passed view when the socket has capacity; copies
+ * into the persistent queue when in quality mode and backpressured.
+ * @param frameView
+ */
+function sendOrQueue(frameView: Uint8Array): void {
+  if (!s.socket || s.socket.readyState !== WebSocket.OPEN || !s.policy) return;
+
+  if (isWsBackpressured(s)) {
+    if (s.policy.dropOnBackpressure) {
+      droppedFrameCount++;
+    } else {
+      enqueueFrame(s, new Uint8Array(frameView));
+    }
+    return;
+  }
+
+  s.socket.send(frameView);
+}
+
+/**
+ * Processes a single AudioData frame: extracts planar f32, tracks timestamp gaps, and emits to the framing pipeline.
+ * @param audioData
+ */
+function processAudioData(audioData: AudioData): void {
+  try {
+    const numFrames = audioData.numberOfFrames;
+    const ts = audioData.timestamp;
+    const sr = audioData.sampleRate;
+
+    if (!loggedFirstFrame) {
+      loggedFirstFrame = true;
+      s.log.info(
+        `First AudioData: format=${audioData.format}, frames=${numFrames}, ` +
+          `channels=${audioData.numberOfChannels}, sampleRate=${sr}, ` +
+          `duration=${audioData.duration}µs, timestamp=${ts}µs`,
+      );
+    }
+
+    if (expectedNextTimestamp >= 0 && ts > 0) {
+      const gap = ts - expectedNextTimestamp;
+      if (Math.abs(gap) > 100) {
+        gapCount++;
+        gapDurationUs += Math.abs(gap);
+      }
+    }
+    if (ts > 0 && sr > 0) {
+      expectedNextTimestamp = ts + Math.round((numFrames / sr) * 1_000_000);
+    }
+
+    ensureTempBuffers(numFrames);
+    audioData.copyTo(ch0Temp!, { planeIndex: 0 });
+    const ch1 = channels >= 2 && audioData.numberOfChannels >= 2 ? ch1Temp : null;
+    if (ch1) {
+      audioData.copyTo(ch1!, { planeIndex: 1 });
+    }
+
+    emitFloat32Samples(ch0Temp!, ch1, numFrames);
+
+    totalSamplesRead += numFrames * channels;
+  } finally {
+    audioData.close();
+  }
+}
+
+/** Main loop: reads AudioData from the MSTP reader, handles backpressure, and posts periodic stats. */
+async function consumeLoopMSTP(): Promise<void> {
+  if (!audioReader) return;
+  s.lastStatsTime = performance.now();
+
+  while (running) {
+    if (!s.policy?.dropOnBackpressure && s.frameQueue.length > 0) {
+      flushFrameQueue(s);
+    }
+
+    const shouldBackoff = s.policy?.dropOnBackpressure
+      ? isWsBackpressured(s)
+      : s.frameQueueBytes >= FRAME_QUEUE_MAX_BYTES;
+
+    if (shouldBackoff) {
+      backpressureCycles++;
+      consecutiveBackpressureCycles++;
+      const maxMs = s.policy?.dropOnBackpressure
+        ? BACKPRESSURE_BACKOFF_MAX_MS
+        : QUALITY_BACKOFF_MAX_MS;
+      const backoffMs = exponentialBackoff(
+        consecutiveBackpressureCycles,
+        BACKPRESSURE_BACKOFF_INITIAL_MS,
+        maxMs,
+      );
+      maybePostStats(s, null, 0, getCustomMetrics, resetCustomCounters);
+      await yieldMacrotask(backoffMs);
+      continue;
+    }
+
+    consecutiveBackpressureCycles = 0;
+
+    const { value: audioData, done } = await audioReader.read();
+    if (done || !running) break;
+
+    processAudioData(audioData);
+    wakeupCount++;
+
+    maybePostStats(s, null, 0, getCustomMetrics, resetCustomCounters);
+  }
+}
+
+/**
+ * Returns worker-specific metrics for the current stats interval.
+ * @returns Metrics snapshot consumed by `maybePostStats`.
+ */
+function getCustomMetrics(): CustomMetrics {
+  return {
+    underflows: 0,
+    consumerDroppedFrames: droppedFrameCount,
+    catchUpDroppedSamples: 0,
+    backpressureCycles,
+    wakeups: wakeupCount,
+    avgSamplesPerWake: wakeupCount > 0 ? totalSamplesRead / wakeupCount : 0,
+    encodeQueueSize: 0,
+  };
+}
+
+/** Resets per-interval counters after stats are posted; logs a debug line if timestamp gaps occurred. */
+function resetCustomCounters(): void {
+  if (gapCount > 0) {
+    s.log.debug(`AudioData gaps: ${gapCount} gaps, ${(gapDurationUs / 1000).toFixed(1)}ms total`);
+  }
+  wakeupCount = 0;
+  totalSamplesRead = 0;
+  droppedFrameCount = 0;
+  backpressureCycles = 0;
+  gapCount = 0;
+  gapDurationUs = 0;
+}
+
+/** Stops the consume loop, cancels the MSTP reader, releases buffers, and tears down shared WS state. */
+function cleanup(): void {
+  running = false;
+
+  if (audioReader) {
+    audioReader.cancel().catch(() => {
+      /* ignore cancel errors during shutdown */
+    });
+    audioReader = null;
+  }
+
+  flushQueuedFrames(s);
+
+  ch0Temp = null;
+  ch1Temp = null;
+  accum = null;
+  accumOffset = 0;
+  accumView = null;
+  maxFrameSamples = 0;
+  loggedFirstFrame = false;
+  expectedNextTimestamp = -1;
+  gapCount = 0;
+  gapDurationUs = 0;
+
+  cleanupSharedState(s);
+}
+
+self.onmessage = async (event: MessageEvent<WorkerInboundMessage>) => {
+  const msg = event.data;
+  if (handleCommonMessage(s, msg, cleanup)) return;
+
+  if (msg.type === 'INIT') {
+    try {
+      const { encoderConfig, wsUrl, frameSizeInterleaved: initFrameSize } = msg;
+
+      if (!initFrameSize || initFrameSize <= 0) {
+        throw new Error('frameSizeInterleaved required for relay worker');
+      }
+      if (!msg.readable) {
+        throw new Error('readable stream required for relay worker');
+      }
+
+      frameSizeInterleaved = initFrameSize;
+      channels = msg.channels ?? 2;
+
+      s.policy = getStreamingPolicy(encoderConfig.latencyMode);
+      s.log.info(
+        `Streaming policy: ${encoderConfig.latencyMode} mode ` +
+          `(dropOnBackpressure=${s.policy.dropOnBackpressure})`,
+      );
+
+      resetStatsCounters(s);
+      resetFrameQueueState(s);
+      wakeupCount = 0;
+      totalSamplesRead = 0;
+      droppedFrameCount = 0;
+      backpressureCycles = 0;
+      consecutiveBackpressureCycles = 0;
+      loggedFirstFrame = false;
+      expectedNextTimestamp = -1;
+      gapCount = 0;
+      gapDurationUs = 0;
+
+      // Chrome typically delivers ~480 samples at 48kHz
+      maxFrameSamples = 1024;
+      ch0Temp = new Float32Array(maxFrameSamples);
+      ch1Temp = new Float32Array(maxFrameSamples);
+
+      // 4x frame headroom for variable AudioData sizes
+      accum = new Int16Array(frameSizeInterleaved * 4);
+      accumOffset = 0;
+      refreshAccumView();
+
+      audioReader = msg.readable.getReader();
+
+      const configWithFrameSize: EncoderConfig = {
+        ...encoderConfig,
+        frameSizeSamples: frameSizeInterleaved / channels,
+      };
+
+      const id = await connectWebSocket(s, wsUrl, {
+        type: 'HANDSHAKE',
+        payload: { encoderConfig: configWithFrameSize },
+      });
+
+      running = true;
+      s.streamStartTime = performance.now();
+      postToMain({ type: 'CONNECTED', streamId: id });
+
+      consumeLoopMSTP().catch((err) => {
+        s.log.error('consumeLoopMSTP error:', err);
+        postToMain({ type: 'ERROR', message: String(err) });
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      s.log.error('Initialization failed:', message);
+      postToMain({ type: 'ERROR', message });
+    }
+  }
+};

--- a/apps/extension/src/offscreen/audio-relay.worker.ts
+++ b/apps/extension/src/offscreen/audio-relay.worker.ts
@@ -53,7 +53,7 @@ let maxFrameSamples = 0;
 // bytes synchronously, so the backing buffer is safe to reuse next frame.
 let accum: Int16Array | null = null;
 let accumOffset = 0;
-let accumView: Uint8Array | null = null;
+let accumView: Uint8Array<ArrayBuffer> | null = null;
 
 // Gaps in AudioData timestamps represent clock reporting jitter, NOT missing
 // audio — the capture device delivers continuous samples.
@@ -164,7 +164,7 @@ function emitFloat32Samples(
  * into the persistent queue when in quality mode and backpressured.
  * @param frameView
  */
-function sendOrQueue(frameView: Uint8Array): void {
+function sendOrQueue(frameView: Uint8Array<ArrayBuffer>): void {
   if (!s.socket || s.socket.readyState !== WebSocket.OPEN || !s.policy) return;
 
   if (isWsBackpressured(s)) {

--- a/apps/extension/src/offscreen/encoders/aac-encoder.ts
+++ b/apps/extension/src/offscreen/encoders/aac-encoder.ts
@@ -124,7 +124,7 @@ export class AacEncoder extends BaseAudioEncoder {
    * @param rawAac - The raw AAC frame data
    * @returns ADTS-wrapped frame
    */
-  private wrapWithAdts(rawAac: Uint8Array): Uint8Array {
+  private wrapWithAdts(rawAac: Uint8Array): Uint8Array<ArrayBuffer> {
     const frameLength = rawAac.byteLength + 7;
     const h = this.adtsHeader;
 

--- a/apps/extension/src/offscreen/encoders/base-encoder.ts
+++ b/apps/extension/src/offscreen/encoders/base-encoder.ts
@@ -28,7 +28,7 @@ const DEFAULT_BUFFER_CAPACITY = 960;
  */
 export abstract class BaseAudioEncoder implements AudioEncoder {
   protected encoder: globalThis.AudioEncoder;
-  protected outputQueue: Uint8Array[] = [];
+  protected outputQueue: Uint8Array<ArrayBuffer>[] = [];
   protected timestamp = 0;
   protected isClosed = false;
   protected readonly log: Logger;
@@ -147,7 +147,7 @@ export abstract class BaseAudioEncoder implements AudioEncoder {
    * Consolidates output queue into a single buffer.
    * @returns Consolidated output or null if queue is empty
    */
-  protected consolidateOutput(): Uint8Array | null {
+  protected consolidateOutput(): Uint8Array<ArrayBuffer> | null {
     if (this.outputQueue.length === 0) {
       return null;
     }
@@ -236,7 +236,7 @@ export abstract class BaseAudioEncoder implements AudioEncoder {
    * @param samples - Interleaved Float32 samples (mono or stereo, range [-1.0, 1.0])
    * @returns Encoded data or null if unavailable
    */
-  encode(samples: Float32Array): Uint8Array | null {
+  encode(samples: Float32Array): Uint8Array<ArrayBuffer> | null {
     if (this.isClosed) return null;
 
     const { planarData, frameCount } = this.convertToPlanar(samples);
@@ -253,7 +253,7 @@ export abstract class BaseAudioEncoder implements AudioEncoder {
    * Flushes any remaining encoded data.
    * @returns Remaining encoded data or null if empty
    */
-  flush(): Uint8Array | null {
+  flush(): Uint8Array<ArrayBuffer> | null {
     if (this.isClosed) return null;
 
     try {
@@ -285,7 +285,7 @@ export abstract class BaseAudioEncoder implements AudioEncoder {
    * @param options - New configuration options
    * @returns Flushed data from the old encoder, or null if nothing was buffered
    */
-  reconfigure(options: ReconfigureOptions): Uint8Array | null {
+  reconfigure(options: ReconfigureOptions): Uint8Array<ArrayBuffer> | null {
     if (this.isClosed) return null;
 
     // Check if there's actually anything to change
@@ -297,7 +297,7 @@ export abstract class BaseAudioEncoder implements AudioEncoder {
     this.log.info(`Reconfiguring encoder: latencyMode ${this._latencyMode} -> ${newLatencyMode}`);
 
     // Flush and collect any pending output
-    let flushedData: Uint8Array | null = null;
+    let flushedData: Uint8Array<ArrayBuffer> | null = null;
     try {
       // Synchronously trigger flush (async completion handled by output callback)
       this.encoder.flush().catch(() => {

--- a/apps/extension/src/offscreen/encoders/flac-encoder.ts
+++ b/apps/extension/src/offscreen/encoders/flac-encoder.ts
@@ -125,7 +125,7 @@ export class FlacEncoder extends BaseAudioEncoder {
    * @param samples - Interleaved Float32 samples (range [-1.0, 1.0])
    * @returns Encoded FLAC data or null if unavailable
    */
-  override encode(samples: Float32Array): Uint8Array | null {
+  override encode(samples: Float32Array): Uint8Array<ArrayBuffer> | null {
     if (this.config.bitsPerSample === 24) {
       return this.encode24Bit(samples);
     }
@@ -138,7 +138,7 @@ export class FlacEncoder extends BaseAudioEncoder {
    * @param samples - Interleaved Float32 samples
    * @returns Encoded FLAC data or null if unavailable
    */
-  private encode24Bit(samples: Float32Array): Uint8Array | null {
+  private encode24Bit(samples: Float32Array): Uint8Array<ArrayBuffer> | null {
     const { planarData, frameCount } = this.convertToInt32Planar(samples);
 
     const data = new AudioData({
@@ -216,12 +216,14 @@ export class FlacEncoder extends BaseAudioEncoder {
     // First chunk should include decoderConfig with the FLAC stream header
     if (!this.headerSent && metadata?.decoderConfig?.description) {
       const description = metadata.decoderConfig.description;
-      // Handle both ArrayBuffer and ArrayBufferView, respecting byteOffset/byteLength
-      const headerData =
+      // Handle both ArrayBuffer and ArrayBufferView, respecting byteOffset/byteLength.
+      // WebCodecs gives us ArrayBuffer-backed data at runtime; cast through ArrayBufferLike
+      // erasure without copying since this is a one-time header emission, not a hot path.
+      const headerData: Uint8Array<ArrayBuffer> =
         description instanceof ArrayBuffer
           ? new Uint8Array(description)
           : new Uint8Array(
-              (description as ArrayBufferView).buffer,
+              (description as ArrayBufferView).buffer as ArrayBuffer,
               (description as ArrayBufferView).byteOffset,
               (description as ArrayBufferView).byteLength,
             );

--- a/apps/extension/src/offscreen/encoders/pcm-encoder.ts
+++ b/apps/extension/src/offscreen/encoders/pcm-encoder.ts
@@ -62,13 +62,14 @@ export class PcmEncoder implements AudioEncoder {
    * @param samples - Interleaved Float32 PCM samples (range [-1.0, 1.0])
    * @returns Raw Int16 bytes to send over WebSocket
    */
-  encode(samples: Float32Array): Uint8Array {
+  encode(samples: Float32Array): Uint8Array<ArrayBuffer> {
     // Advance timestamp for consistency with other encoders
     const frameCount = samples.length / this.config.channels;
     this.timestamp += (frameCount / this.config.sampleRate) * 1_000_000;
 
     // Fresh buffer each call - no reuse means no WebSocket async copy issues
-    const int16 = new Int16Array(samples.length);
+    const buffer = new ArrayBuffer(samples.length * 2);
+    const int16 = new Int16Array(buffer);
 
     // Convert Float32 to Int16 with TPDF dithering
     // Dithering decorrelates quantization error from the signal, converting
@@ -84,7 +85,7 @@ export class PcmEncoder implements AudioEncoder {
     }
 
     // Return view of the fresh buffer - safe since buffer isn't reused
-    return new Uint8Array(int16.buffer);
+    return new Uint8Array(buffer);
   }
 
   /**
@@ -100,7 +101,7 @@ export class PcmEncoder implements AudioEncoder {
    * Returns null since PCM conversion has no buffering.
    * @returns Always null
    */
-  flush(): Uint8Array | null {
+  flush(): Uint8Array<ArrayBuffer> | null {
     return null;
   }
 
@@ -109,7 +110,7 @@ export class PcmEncoder implements AudioEncoder {
    * Latency mode reconfiguration is not applicable to format conversion.
    * @returns Always null
    */
-  reconfigure(): Uint8Array | null {
+  reconfigure(): Uint8Array<ArrayBuffer> | null {
     return null;
   }
 

--- a/apps/extension/src/offscreen/encoders/types.ts
+++ b/apps/extension/src/offscreen/encoders/types.ts
@@ -25,14 +25,14 @@ export interface AudioEncoder {
    * @param samples - Raw PCM samples from AudioWorklet
    * @returns Encoded bytes to send over WebSocket, or null if buffering
    */
-  encode(samples: Float32Array): Uint8Array | null;
+  encode(samples: Float32Array): Uint8Array<ArrayBuffer> | null;
 
   /**
    * Flushes any remaining buffered data.
    * Call before stopping the stream.
    * @returns Final encoded bytes, or null if nothing buffered
    */
-  flush(): Uint8Array | null;
+  flush(): Uint8Array<ArrayBuffer> | null;
 
   /**
    * Releases encoder resources.
@@ -73,5 +73,5 @@ export interface AudioEncoder {
    * @param options - New configuration options
    * @returns Flushed data from the old encoder, or null if nothing was buffered
    */
-  reconfigure(options: ReconfigureOptions): Uint8Array | null;
+  reconfigure(options: ReconfigureOptions): Uint8Array<ArrayBuffer> | null;
 }

--- a/apps/extension/src/offscreen/encoders/vorbis-encoder.ts
+++ b/apps/extension/src/offscreen/encoders/vorbis-encoder.ts
@@ -111,7 +111,11 @@ export class VorbisEncoder extends BaseAudioEncoder {
    * @param granule - Granule position
    * @returns The complete Ogg page
    */
-  private createOggPage(packets: Uint8Array[], flags: number, granule: bigint): Uint8Array {
+  private createOggPage(
+    packets: Uint8Array[],
+    flags: number,
+    granule: bigint,
+  ): Uint8Array<ArrayBuffer> {
     // Calculate segment table
     const segments: number[] = [];
     let totalDataSize = 0;

--- a/apps/extension/src/offscreen/stream-session.ts
+++ b/apps/extension/src/offscreen/stream-session.ts
@@ -79,6 +79,9 @@ export class StreamSession {
   /** Timer for checking worklet heartbeat. */
   private heartbeatCheckTimer: ReturnType<typeof setInterval> | null = null;
 
+  /** Pending worker terminate timer (deferred to allow METRICS_DUMP delivery). */
+  private workerTerminateTimer: ReturnType<typeof setTimeout> | null = null;
+
   /** Time when the current stall started (0 if not stalled). */
   private stallStartTime = 0;
 
@@ -610,6 +613,11 @@ export class StreamSession {
           }
           break;
         }
+
+        case 'METRICS_DUMP':
+          log.info('Pipeline metrics timeline', { timeline: JSON.stringify(msg.timeline) });
+          this.terminateWorkerNow();
+          break;
       }
     };
 
@@ -652,8 +660,8 @@ export class StreamSession {
 
     if (this.consumerWorker) {
       this.consumerWorker.postMessage({ type: 'STOP' });
-      this.consumerWorker.terminate();
-      this.consumerWorker = null;
+      // Defer terminate to allow worker to post METRICS_DUMP back
+      this.workerTerminateTimer = setTimeout(() => this.terminateWorkerNow(), 500);
     }
 
     // Audio pipeline cleanup (tab capture only)
@@ -675,6 +683,20 @@ export class StreamSession {
       this.outputGainNode?.disconnect();
       this.audioContext?.close().catch(noop);
       this.mediaStream.getTracks().forEach((t) => t.stop());
+    }
+  }
+
+  /**
+   * Terminates the consumer worker immediately and clears the deferred terminate timer.
+   */
+  private terminateWorkerNow(): void {
+    if (this.workerTerminateTimer) {
+      clearTimeout(this.workerTerminateTimer);
+      this.workerTerminateTimer = null;
+    }
+    if (this.consumerWorker) {
+      this.consumerWorker.terminate();
+      this.consumerWorker = null;
     }
   }
 

--- a/apps/extension/src/offscreen/stream-session.ts
+++ b/apps/extension/src/offscreen/stream-session.ts
@@ -24,9 +24,9 @@
 import { createLogger } from '@thaumic-cast/shared';
 import { createAudioRingBuffer, HEADER_SIZE } from './ring-buffer';
 import type { EncoderConfig, StreamMetadata } from '@thaumic-cast/protocol';
-import { isSupportedSampleRate } from '@thaumic-cast/protocol';
+import { FRAME_DURATION_MS_DEFAULT, isSupportedSampleRate } from '@thaumic-cast/protocol';
+import type { WorkerInitMessage, WorkerOutboundMessage } from './worker-messages';
 import { noop } from '../lib/noop';
-import type { WorkerOutboundMessage } from './worker-messages';
 
 const log = createLogger('Offscreen');
 
@@ -65,22 +65,30 @@ const KEEP_AUDIBLE_GAIN = 0.0001;
 export class StreamSession {
   private audioContext: AudioContext | null = null;
   private consumerWorker: Worker | null = null;
-  // Ring buffer is created in setupAudioPipeline() after sample rate is verified
-  private ringBuffer!: SharedArrayBuffer;
-  private bufferSize!: number;
-  private bufferMask!: number;
+  // Ring buffer is created in setupAudioContextPipeline() after sample rate is verified
+  private ringBuffer: SharedArrayBuffer | null = null;
+  private bufferSize = 0;
+  private bufferMask = 0;
   private sourceNode: MediaStreamAudioSourceNode | null = null;
   private workletNode: AudioWorkletNode | null = null;
   private outputGainNode: GainNode | null = null;
+
+  // ─── MSTP path (PCM codec) ──────────────────────────────────────
+  private trackProcessor: MediaStreamTrackProcessor | null = null;
+  /** Audio element for keepTabAudible in MSTP mode (avoids AudioContext clock domain crossing). */
+  private audibleAudio: HTMLAudioElement | null = null;
+
+  /** Number of interleaved samples per frame (PCM encode path only). */
+  private frameSizeInterleaved?: number;
+
+  /** Pending worker terminate timer (deferred to allow METRICS_DUMP delivery). */
+  private workerTerminateTimer: ReturnType<typeof setTimeout> | null = null;
 
   /** Last time we received a heartbeat from the worklet. */
   private lastWorkletHeartbeat = 0;
 
   /** Timer for checking worklet heartbeat. */
   private heartbeatCheckTimer: ReturnType<typeof setInterval> | null = null;
-
-  /** Pending worker terminate timer (deferred to allow METRICS_DUMP delivery). */
-  private workerTerminateTimer: ReturnType<typeof setTimeout> | null = null;
 
   /** Time when the current stall started (0 if not stalled). */
   private stallStartTime = 0;
@@ -161,6 +169,7 @@ export class StreamSession {
    * @param onDisconnected - Optional callback when worker WebSocket disconnects
    * @param options - Additional session options
    * @param options.keepTabAudible - Play audio at low volume to prevent Chrome throttling
+   * @returns A new StreamSession configured for tab audio capture
    */
   static forTabCapture(
     mediaStream: MediaStream,
@@ -187,6 +196,7 @@ export class StreamSession {
    * @param onDisconnected - Optional callback when worker WebSocket disconnects
    * @param onError - Optional callback when server reports a capture error
    * @param browserName - Optional browser executable name for PID lookup
+   * @returns A new StreamSession configured for browser-wide WASAPI capture
    */
   static forBrowserCapture(
     encoderConfig: EncoderConfig,
@@ -207,16 +217,17 @@ export class StreamSession {
   }
 
   /**
-   *
-   * @param config
-   * @param config.captureMode
-   * @param config.mediaStream
-   * @param config.encoderConfig
-   * @param config.baseUrl
-   * @param config.onDisconnected
-   * @param config.onError
-   * @param config.keepTabAudible
-   * @param config.browserName
+   * Constructs a StreamSession. Use the static {@link forTabCapture} or
+   * {@link forBrowserCapture} factories instead of calling this directly.
+   * @param config - Session configuration
+   * @param config.captureMode - 'tab' for per-tab capture, 'browser' for WASAPI browser-wide capture
+   * @param config.mediaStream - MediaStream for tab capture (null in browser capture mode)
+   * @param config.encoderConfig - Audio encoder configuration
+   * @param config.baseUrl - Desktop app base URL
+   * @param config.onDisconnected - Optional callback when worker WebSocket disconnects
+   * @param config.onError - Optional callback when server reports a capture error
+   * @param config.keepTabAudible - Play audio at low volume to prevent Chrome throttling (tab capture only)
+   * @param config.browserName - Browser executable name for PID lookup (browser capture only)
    */
   private constructor(config: {
     captureMode: 'tab' | 'browser';
@@ -267,9 +278,103 @@ export class StreamSession {
   }
 
   /**
-   * Sets up the Web Audio graph and loads the AudioWorklet.
+   * Sets up the audio capture pipeline.
+   * Routes to MSTP (PCM codec) or AudioContext (compressed codecs) path.
    */
   private async setupAudioPipeline(): Promise<void> {
+    // Set up MediaStream track monitoring (shared by both paths)
+    this.setupTrackMonitoring();
+
+    if (this.encoderConfig.codec === 'pcm') {
+      this.setupMSTPPipeline();
+    } else {
+      await this.setupAudioContextPipeline();
+    }
+  }
+
+  /**
+   * Sets up MediaStream track event listeners for monitoring mute/unmute/ended states.
+   */
+  private setupTrackMonitoring(): void {
+    const audioTracks = this.mediaStream!.getAudioTracks();
+    log.info(`MediaStream has ${audioTracks.length} audio track(s)`);
+
+    for (const track of audioTracks) {
+      log.info(
+        `Audio track: ${track.label}, enabled=${track.enabled}, muted=${track.muted}, readyState=${track.readyState}`,
+      );
+
+      // Log track settings
+      const settings = track.getSettings();
+      log.info(
+        `Track settings: sampleRate=${settings.sampleRate} channels=${settings.channelCount}`,
+      );
+
+      // Monitor track mute state changes
+      track.onmute = () => {
+        log.warn(`Audio track MUTED: ${track.label || 'unnamed'}`);
+      };
+
+      track.onunmute = () => {
+        log.info(`Audio track UNMUTED: ${track.label || 'unnamed'}`);
+      };
+
+      // Monitor track ending (tab closed, permission revoked, etc.)
+      track.onended = () => {
+        log.warn(`Audio track ENDED: ${track.label || 'unnamed'}, readyState=${track.readyState}`);
+      };
+    }
+  }
+
+  /**
+   * Sets up the MSTP (MediaStreamTrackProcessor) pipeline for PCM codec.
+   * Bypasses AudioContext entirely — reads raw AudioData frames from the track.
+   */
+  private setupMSTPPipeline(): void {
+    const audioTrack = this.mediaStream!.getAudioTracks()[0];
+    if (!audioTrack) throw new Error('No audio track available in MediaStream');
+
+    // Override sample rate to track's native rate (MSTP bypasses AudioContext resampling)
+    const trackSampleRate = audioTrack.getSettings().sampleRate;
+    if (
+      trackSampleRate &&
+      isSupportedSampleRate(trackSampleRate) &&
+      trackSampleRate !== this.encoderConfig.sampleRate
+    ) {
+      log.info(
+        `MSTP: overriding sample rate ${this.encoderConfig.sampleRate}Hz → ${trackSampleRate}Hz (capture native rate)`,
+      );
+      this.encoderConfig = { ...this.encoderConfig, sampleRate: trackSampleRate };
+    }
+
+    // Compute frame size
+    const frameDurationMs = this.encoderConfig.frameDurationMs ?? FRAME_DURATION_MS_DEFAULT;
+    const perChannelSamples = Math.round(this.encoderConfig.sampleRate * (frameDurationMs / 1000));
+    this.frameSizeInterleaved = perChannelSamples * this.encoderConfig.channels;
+
+    // Create MediaStreamTrackProcessor
+    const maxBufferSize = 1000;
+    this.trackProcessor = new MediaStreamTrackProcessor({ track: audioTrack, maxBufferSize });
+    log.info(
+      `MSTP pipeline: maxBufferSize=${maxBufferSize}, frameSizeInterleaved=${this.frameSizeInterleaved}`,
+    );
+
+    // keepTabAudible: use <audio> element at near-zero volume (avoids AudioContext clock domain crossing)
+    if (this.keepTabAudible) {
+      this.audibleAudio = document.createElement('audio');
+      this.audibleAudio.srcObject = this.mediaStream;
+      this.audibleAudio.volume = KEEP_AUDIBLE_GAIN;
+      this.audibleAudio.play().catch((err) => {
+        log.warn('Keep tab audible: audio.play() failed:', err);
+      });
+      log.info('Keep tab audible enabled (MSTP) - audio element at low volume');
+    }
+  }
+
+  /**
+   * Sets up the Web Audio graph and loads the AudioWorklet (compressed codecs path).
+   */
+  private async setupAudioContextPipeline(): Promise<void> {
     // Create AudioContext - browser may give us a different sample rate than requested
     // Use 'interactive' for realtime mode to minimize latency on capable devices
     // Use 'playback' for quality mode to prioritize power efficiency
@@ -329,7 +434,7 @@ export class StreamSession {
 
     this.workletNode.port.postMessage({
       type: 'INIT_BUFFER',
-      buffer: this.ringBuffer,
+      buffer: this.ringBuffer!,
       bufferSize: this.bufferSize,
       bufferMask: this.bufferMask,
       headerSize: HEADER_SIZE,
@@ -395,30 +500,6 @@ export class StreamSession {
     }
     log.info(`AudioContext state: ${this.audioContext.state}`);
 
-    // Set up MediaStream track monitoring
-    const audioTracks = this.mediaStream!.getAudioTracks();
-    log.info(`MediaStream has ${audioTracks.length} audio track(s)`);
-
-    for (const track of audioTracks) {
-      log.info(
-        `Audio track: ${track.label}, enabled=${track.enabled}, muted=${track.muted}, readyState=${track.readyState}`,
-      );
-
-      // Monitor track mute state changes
-      track.onmute = () => {
-        log.warn(`Audio track MUTED: ${track.label || 'unnamed'}`);
-      };
-
-      track.onunmute = () => {
-        log.info(`Audio track UNMUTED: ${track.label || 'unnamed'}`);
-      };
-
-      // Monitor track ending (tab closed, permission revoked, etc.)
-      track.onended = () => {
-        log.warn(`Audio track ENDED: ${track.label || 'unnamed'}, readyState=${track.readyState}`);
-      };
-    }
-
     // Initialize heartbeat tracking and start checker
     this.lastWorkletHeartbeat = performance.now();
     this.startHeartbeatChecker();
@@ -483,9 +564,16 @@ export class StreamSession {
   private async startWorker(): Promise<void> {
     const wsUrl = this.baseUrl.replace(/^http/, 'ws') + '/ws';
 
-    this.consumerWorker = new Worker(new URL('./audio-consumer.worker.ts', import.meta.url), {
-      type: 'module',
-    });
+    // Spawn codec-appropriate worker
+    if (this.encoderConfig.codec === 'pcm') {
+      this.consumerWorker = new Worker(new URL('./audio-relay.worker.ts', import.meta.url), {
+        type: 'module',
+      });
+    } else {
+      this.consumerWorker = new Worker(new URL('./audio-consumer.worker.ts', import.meta.url), {
+        type: 'module',
+      });
+    }
 
     // Create promise for connection
     const connectionPromise = new Promise<string>((resolve, reject) => {
@@ -558,6 +646,11 @@ export class StreamSession {
           this.stop();
           break;
 
+        case 'METRICS_DUMP':
+          log.info('Pipeline metrics timeline', { timeline: JSON.stringify(msg.timeline) });
+          this.terminateWorkerNow();
+          break;
+
         case 'STATS': {
           // Accumulate drops for session health reporting
           this.totalProducerDrops += msg.producerDroppedSamples ?? 0;
@@ -613,11 +706,6 @@ export class StreamSession {
           }
           break;
         }
-
-        case 'METRICS_DUMP':
-          log.info('Pipeline metrics timeline', { timeline: JSON.stringify(msg.timeline) });
-          this.terminateWorkerNow();
-          break;
       }
     };
 
@@ -627,18 +715,36 @@ export class StreamSession {
       this.connectionResolver = null;
     };
 
-    // Initialize the Worker based on capture mode
+    // Initialize the Worker based on capture mode and codec
     if (this.captureMode === 'browser') {
+      // Browser capture path (unchanged — worker manages WS lifecycle only)
       this.consumerWorker.postMessage({
         type: 'INIT_BROWSER_CAPTURE',
         wsUrl,
         encoderConfig: this.encoderConfig,
         browserName: this.browserName,
       });
+    } else if (this.encoderConfig.codec === 'pcm' && this.trackProcessor) {
+      // MSTP path: transfer ReadableStream to worker
+      const readable = this.trackProcessor.readable;
+      const initMsg: WorkerInitMessage = {
+        type: 'INIT',
+        sampleRate: this.encoderConfig.sampleRate,
+        encoderConfig: this.encoderConfig,
+        wsUrl,
+        mode: 'encode',
+        frameSizeInterleaved: this.frameSizeInterleaved,
+        readable,
+        channels: this.encoderConfig.channels,
+      };
+      this.consumerWorker.postMessage(initMsg, {
+        transfer: [readable as unknown as Transferable],
+      });
     } else {
+      // SAB path: compressed codecs
       this.consumerWorker.postMessage({
         type: 'INIT',
-        sab: this.ringBuffer,
+        sab: this.ringBuffer!,
         bufferSize: this.bufferSize,
         bufferMask: this.bufferMask,
         headerSize: HEADER_SIZE,
@@ -678,16 +784,26 @@ export class StreamSession {
         track.onended = null;
       }
 
+      // Tear down AudioContext path (compressed codecs)
       this.sourceNode?.disconnect();
       this.workletNode?.disconnect();
       this.outputGainNode?.disconnect();
       this.audioContext?.close().catch(noop);
+
+      // Tear down MSTP path resources
+      this.trackProcessor = null; // ReadableStream was transferred to worker
+      if (this.audibleAudio) {
+        this.audibleAudio.pause();
+        this.audibleAudio.srcObject = null;
+        this.audibleAudio = null;
+      }
+
       this.mediaStream.getTracks().forEach((t) => t.stop());
     }
   }
 
   /**
-   * Terminates the consumer worker immediately and clears the deferred terminate timer.
+   * Terminates the worker immediately and clears the deferred-terminate timer.
    */
   private terminateWorkerNow(): void {
     if (this.workerTerminateTimer) {

--- a/apps/extension/src/offscreen/worker-base.ts
+++ b/apps/extension/src/offscreen/worker-base.ts
@@ -1,0 +1,786 @@
+/**
+ * Shared Worker Infrastructure
+ *
+ * Extracted from audio-consumer.worker.ts to enable reuse across worker types.
+ * Contains WebSocket management, frame queue, stats, flow control, and cleanup
+ * logic shared between the SAB-based audio consumer worker and the MSTP
+ * (MediaStreamTrackProcessor) relay worker.
+ */
+
+import type { WsMessage } from '@thaumic-cast/protocol';
+import type {
+  WorkerInboundMessage,
+  WorkerOutboundMessage,
+  MetricSnapshot,
+} from './worker-messages';
+import {
+  WsMessageSchema,
+  type StreamingPolicy,
+  FRAME_QUEUE_HYSTERESIS_RATIO,
+} from '@thaumic-cast/protocol';
+import { createLogger, Logger } from '@thaumic-cast/shared';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Initial backpressure backoff delay (ms). */
+export const BACKPRESSURE_BACKOFF_INITIAL_MS = 5;
+
+/** Maximum backpressure backoff delay for realtime mode (ms). */
+export const BACKPRESSURE_BACKOFF_MAX_MS = 40;
+
+/** Maximum backpressure backoff delay for quality mode (ms). */
+export const QUALITY_BACKOFF_MAX_MS = 50;
+
+/** Timeout for waiting on producer (ms). Triggers underflow if exceeded. 200ms = 20 frames of headroom. */
+export const WAIT_TIMEOUT_MS = 200;
+
+/** Interval for posting diagnostic stats to main thread (ms). */
+export const STATS_INTERVAL_MS = 2000;
+
+/** Heartbeat interval for WebSocket (ms). */
+export const HEARTBEAT_INTERVAL_MS = 5000;
+
+/**
+ * Maximum frame queue size in bytes (~30 seconds of audio).
+ * At 48kHz/16-bit stereo PCM: ~5.76MB for 30s. With headroom: 8MB.
+ */
+export const FRAME_QUEUE_MAX_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Target frame queue size after overflow trimming.
+ * Uses hysteresis ratio from streaming policy to prevent oscillation.
+ */
+export const FRAME_QUEUE_TARGET_BYTES = Math.floor(
+  FRAME_QUEUE_MAX_BYTES * FRAME_QUEUE_HYSTERESIS_RATIO,
+);
+
+/** WebSocket connection timeout (ms). */
+const WS_CONNECT_TIMEOUT_MS = 5000;
+
+/** Handshake timeout (ms). */
+const HANDSHAKE_TIMEOUT_MS = 5000;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Worker-specific metrics returned by the getCustomMetrics callback.
+ * Each worker provides its own implementation of these fields.
+ */
+export interface CustomMetrics {
+  /** Underflow events (buffer empty when reading). */
+  underflows: number;
+  /** Frames dropped by worker (backpressure in realtime mode). */
+  consumerDroppedFrames: number;
+  /** Samples dropped by catch-up logic (bounded latency). */
+  catchUpDroppedSamples: number;
+  /** Cycles where drain was skipped due to backpressure. */
+  backpressureCycles: number;
+  /** Number of wakeups in this stats interval. */
+  wakeups: number;
+  /** Average samples read per wakeup. */
+  avgSamplesPerWake: number;
+  /** Current encoder queue depth. */
+  encodeQueueSize: number;
+}
+
+/**
+ * Shared state for worker infrastructure.
+ * Contains WebSocket, streaming policy, counters, frame queue, metrics timeline,
+ * and logger. Does NOT include worker-specific state like SAB control arrays,
+ * encoders, or ring buffers.
+ */
+export interface WorkerState {
+  /** WebSocket connection to the desktop app. */
+  socket: WebSocket | null;
+  /** Stream identifier assigned by the server handshake. */
+  streamId: string | null;
+  /** Heartbeat interval timer handle. */
+  heartbeatInterval: ReturnType<typeof setInterval> | null;
+  /** Current streaming policy (realtime vs quality mode). */
+  policy: StreamingPolicy | null;
+
+  // Diagnostic counters
+  /** Last time stats were posted (performance.now timestamp). */
+  lastStatsTime: number;
+
+  // Frame queue (quality mode backpressure decoupling)
+  /** Queue of encoded frames waiting to be sent. */
+  frameQueue: Uint8Array[];
+  /** Total bytes currently in frameQueue. */
+  frameQueueBytes: number;
+  /** Count of frames dropped from queue due to overflow. */
+  frameQueueOverflowDrops: number;
+  /** Previous value of producer dropped samples for delta computation. */
+  prevProducerDroppedSamples: number;
+
+  // Metrics timeline
+  /** Time-series of metric snapshots for post-mortem analysis. */
+  metricTimeline: MetricSnapshot[];
+  /** Timestamp of stream start for relative timing (performance.now). */
+  streamStartTime: number;
+
+  /** Logger instance for this worker. */
+  log: Logger;
+
+  /** Whether the worker is in browser capture mode (no local audio pipeline). */
+  browserCaptureMode: boolean;
+}
+
+/** Handshake message to send on WS connect. */
+interface HandshakeMessage {
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a fresh WorkerState with all fields initialized to defaults.
+ * @param name - Logger name for this worker instance
+ * @returns A new WorkerState
+ */
+export function createWorkerState(name: string): WorkerState {
+  return {
+    socket: null,
+    streamId: null,
+    heartbeatInterval: null,
+    policy: null,
+    lastStatsTime: 0,
+    frameQueue: [],
+    frameQueueBytes: 0,
+    frameQueueOverflowDrops: 0,
+    prevProducerDroppedSamples: 0,
+    metricTimeline: [],
+    streamStartTime: 0,
+    log: createLogger(name),
+    browserCaptureMode: false,
+  };
+}
+
+/**
+ * Resets diagnostic stat counters that are interval-scoped.
+ * Called after posting stats to main thread.
+ * @param s - Worker state
+ */
+export function resetStatsCounters(s: WorkerState): void {
+  s.frameQueueOverflowDrops = 0;
+  s.lastStatsTime = performance.now();
+}
+
+/**
+ * Resets frame queue state to initial values.
+ * Used during cleanup and initialization.
+ * @param s - Worker state
+ */
+export function resetFrameQueueState(s: WorkerState): void {
+  s.frameQueue = [];
+  s.frameQueueBytes = 0;
+  s.frameQueueOverflowDrops = 0;
+  s.prevProducerDroppedSamples = 0;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flow Control Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Posts a message to the main thread.
+ * @param message - The outbound message to post
+ */
+export function postToMain(message: WorkerOutboundMessage): void {
+  self.postMessage(message);
+}
+
+/**
+ * Aligns a value down to the nearest multiple of alignment.
+ * @param value - The value to align
+ * @param alignment - The alignment boundary
+ * @returns Aligned value
+ */
+export function alignDown(value: number, alignment: number): number {
+  return Math.floor(value / alignment) * alignment;
+}
+
+/**
+ * Reusable MessageChannel for zero-delay yields.
+ * MessageChannel posts directly to the task queue with sub-millisecond latency,
+ * unlike setTimeout(0) which has minimum 1-4ms delay due to browser throttling.
+ */
+const yieldChannel = new MessageChannel();
+let yieldResolve: (() => void) | null = null;
+yieldChannel.port2.onmessage = () => {
+  yieldResolve?.();
+  yieldResolve = null;
+};
+
+/**
+ * Yields to the macrotask queue.
+ * Unlike microtasks (Promise.resolve), this actually yields CPU time.
+ * @param delayMs - Milliseconds to wait (use 0 to just yield without delay)
+ * @returns A promise that resolves after the delay
+ */
+export function yieldMacrotask(delayMs: number = 0): Promise<void> {
+  if (delayMs === 0) {
+    // Use MessageChannel for zero-delay yield - faster than setTimeout(0)
+    return new Promise((resolve) => {
+      yieldResolve = resolve;
+      yieldChannel.port1.postMessage(null);
+    });
+  }
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+/**
+ * Checks if the WebSocket is backpressured (buffered amount exceeds high water mark).
+ * @param s - Worker state
+ * @returns True if WebSocket buffer is overloaded
+ */
+export function isWsBackpressured(s: WorkerState): boolean {
+  if (!s.policy || !s.socket) return false;
+  return s.socket.bufferedAmount >= s.policy.wsBufferHighWater;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Frame Queue Management (Quality Mode)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Trims the frame queue to target size, dropping oldest frames.
+ * Uses hysteresis (FRAME_QUEUE_HYSTERESIS_RATIO) to prevent oscillation.
+ * Uses splice() once instead of shift() in loop for O(n) vs O(n^2) performance.
+ * @param s - Worker state
+ */
+function trimFrameQueue(s: WorkerState): void {
+  let droppedBytes = 0;
+  let droppedCount = 0;
+  let bytesToDrop = s.frameQueueBytes - FRAME_QUEUE_TARGET_BYTES;
+
+  while (droppedCount < s.frameQueue.length && bytesToDrop > 0) {
+    const frameBytes = s.frameQueue[droppedCount]!.byteLength;
+    droppedBytes += frameBytes;
+    bytesToDrop -= frameBytes;
+    droppedCount++;
+  }
+
+  if (droppedCount > 0) {
+    s.frameQueue.splice(0, droppedCount);
+    s.frameQueueBytes -= droppedBytes;
+    s.frameQueueOverflowDrops += droppedCount;
+    s.log.warn(
+      `Frame queue overflow: dropped ${droppedCount} frames (${(droppedBytes / 1024).toFixed(1)}KB) ` +
+        `to maintain ~30s bound`,
+    );
+  }
+}
+
+/**
+ * Adds an encoded frame to the queue.
+ * If queue exceeds bounds, trims oldest frames to target size.
+ * @param s - Worker state
+ * @param frame - Encoded frame data to queue
+ */
+export function enqueueFrame(s: WorkerState, frame: Uint8Array): void {
+  s.frameQueue.push(frame);
+  s.frameQueueBytes += frame.byteLength;
+
+  if (s.frameQueueBytes > FRAME_QUEUE_MAX_BYTES) {
+    trimFrameQueue(s);
+  }
+}
+
+/**
+ * Attempts to flush queued frames to WebSocket.
+ * Respects WebSocket backpressure - stops when buffer exceeds high water mark.
+ * Uses splice() once at end instead of shift() per frame for O(n) vs O(n^2) performance.
+ * @param s - Worker state
+ * @returns Number of frames sent
+ */
+export function flushFrameQueue(s: WorkerState): number {
+  if (!s.socket || s.socket.readyState !== WebSocket.OPEN || !s.policy) {
+    return 0;
+  }
+
+  let sentCount = 0;
+  let sentBytes = 0;
+
+  while (sentCount < s.frameQueue.length) {
+    if (s.socket.bufferedAmount >= s.policy.wsBufferHighWater) {
+      break;
+    }
+
+    const frame = s.frameQueue[sentCount]!;
+    s.socket.send(frame);
+    sentBytes += frame.byteLength;
+    sentCount++;
+  }
+
+  if (sentCount > 0) {
+    s.frameQueue.splice(0, sentCount);
+    s.frameQueueBytes -= sentBytes;
+  }
+
+  return sentCount;
+}
+
+/**
+ * Flushes all remaining queued frames to WebSocket without backpressure checks.
+ * Used during cleanup/shutdown when we want to drain everything.
+ * @param s - Worker state
+ */
+export function flushQueuedFrames(s: WorkerState): void {
+  if (s.frameQueue.length === 0 || !s.socket || s.socket.readyState !== WebSocket.OPEN) {
+    return;
+  }
+
+  const flushedCount = s.frameQueue.length;
+  const flushedBytes = s.frameQueueBytes;
+
+  for (const frame of s.frameQueue) {
+    s.socket.send(frame);
+  }
+
+  s.log.info(
+    `Flushed ${flushedCount} queued frames (${(flushedBytes / 1024).toFixed(1)}KB) on cleanup`,
+  );
+
+  s.frameQueue = [];
+  s.frameQueueBytes = 0;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stats & Metrics
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Posts diagnostic stats to main thread if the stats interval has elapsed.
+ *
+ * Captures a MetricSnapshot into the timeline and posts a STATS message.
+ * The `control` parameter is nullable: when null (MSTP mode), producer drops
+ * and ring fill fraction are reported as 0.
+ *
+ * @param s - Worker state
+ * @param control - Int32Array for SAB ring buffer header, or null for MSTP mode
+ * @param bufferCapacity - Ring buffer capacity in samples (0 if no ring buffer)
+ * @param getCustomMetrics - Callback returning worker-specific metric fields
+ * @param resetCustomCounters - Optional callback to reset worker-specific interval counters
+ */
+export function maybePostStats(
+  s: WorkerState,
+  control: Int32Array | null,
+  bufferCapacity: number,
+  getCustomMetrics: () => CustomMetrics,
+  resetCustomCounters?: () => void,
+): void {
+  const now = performance.now();
+  if (now - s.lastStatsTime < STATS_INTERVAL_MS) return;
+
+  // Compute producer dropped samples delta (SAB mode only)
+  let producerDroppedSamples = 0;
+  let ringFillFraction = 0;
+
+  if (control) {
+    const { CTRL_DROPPED_SAMPLES, CTRL_WRITE_IDX, CTRL_READ_IDX } = getCtrlIndices();
+    const totalDropped = Atomics.load(control, CTRL_DROPPED_SAMPLES);
+    producerDroppedSamples = (totalDropped - s.prevProducerDroppedSamples) >>> 0;
+    s.prevProducerDroppedSamples = totalDropped;
+
+    if (bufferCapacity > 0) {
+      const writeIdx = Atomics.load(control, CTRL_WRITE_IDX);
+      const readIdx = Atomics.load(control, CTRL_READ_IDX);
+      const available = (writeIdx - readIdx) >>> 0;
+      ringFillFraction = available / bufferCapacity;
+    }
+  }
+
+  const custom = getCustomMetrics();
+
+  // Capture metric snapshot
+  const snapshot: MetricSnapshot = {
+    t: now - s.streamStartTime,
+    fill: ringFillFraction,
+    wsBuf: s.socket?.bufferedAmount ?? 0,
+    uf: custom.underflows,
+    pDrop: producerDroppedSamples,
+    cDrop: custom.consumerDroppedFrames,
+    cuDrop: custom.catchUpDroppedSamples,
+    bp: custom.backpressureCycles,
+    fq: s.frameQueue.length,
+    fqB: s.frameQueueBytes,
+    fqDrop: s.frameQueueOverflowDrops,
+  };
+  s.metricTimeline.push(snapshot);
+
+  postToMain({
+    type: 'STATS',
+    underflows: custom.underflows,
+    producerDroppedSamples,
+    consumerDroppedFrames: custom.consumerDroppedFrames,
+    catchUpDroppedSamples: custom.catchUpDroppedSamples,
+    backpressureCycles: custom.backpressureCycles,
+    wakeups: custom.wakeups,
+    avgSamplesPerWake: custom.avgSamplesPerWake,
+    encodeQueueSize: custom.encodeQueueSize,
+    wsBufferedAmount: s.socket?.bufferedAmount ?? 0,
+    frameQueueSize: s.frameQueue.length,
+    frameQueueBytes: s.frameQueueBytes,
+    frameQueueOverflowDrops: s.frameQueueOverflowDrops,
+  });
+
+  // Reset shared interval counters
+  s.frameQueueOverflowDrops = 0;
+  s.lastStatsTime = now;
+
+  // Reset worker-specific interval counters
+  resetCustomCounters?.();
+}
+
+/**
+ * Returns ring buffer control indices.
+ * Lazily imported to avoid circular dependency with ring-buffer module.
+ */
+function getCtrlIndices(): {
+  CTRL_WRITE_IDX: number;
+  CTRL_READ_IDX: number;
+  CTRL_DROPPED_SAMPLES: number;
+} {
+  // These constants are stable (0, 1, 2) — inline them to avoid import coupling.
+  // Matches ring-buffer.ts: CTRL_WRITE_IDX=0, CTRL_READ_IDX=1, CTRL_DROPPED_SAMPLES=2
+  return { CTRL_WRITE_IDX: 0, CTRL_READ_IDX: 1, CTRL_DROPPED_SAMPLES: 2 };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WebSocket Management
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Starts the heartbeat timer for a worker state.
+ * @param s - Worker state
+ */
+function startHeartbeat(s: WorkerState): void {
+  stopHeartbeat(s);
+  s.heartbeatInterval = setInterval(() => {
+    if (s.socket?.readyState === WebSocket.OPEN) {
+      s.socket.send(JSON.stringify({ type: 'HEARTBEAT' }));
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+}
+
+/**
+ * Stops the heartbeat timer.
+ * @param s - Worker state
+ */
+function stopHeartbeat(s: WorkerState): void {
+  if (s.heartbeatInterval) {
+    clearInterval(s.heartbeatInterval);
+    s.heartbeatInterval = null;
+  }
+}
+
+/**
+ * Handles incoming WebSocket messages after handshake.
+ * Dispatches server messages (STREAM_READY, PLAYBACK_STARTED, errors, etc.) to main thread.
+ * @param s - Worker state
+ * @param event - MessageEvent from WebSocket
+ */
+function handleWsMessage(s: WorkerState, event: MessageEvent): void {
+  if (typeof event.data !== 'string') return;
+
+  try {
+    const raw = JSON.parse(event.data);
+
+    // Skip broadcast events
+    if ('category' in raw || raw.type === 'INITIAL_STATE') return;
+
+    const parsed = WsMessageSchema.safeParse(raw);
+    if (!parsed.success) return;
+
+    const message: WsMessage = parsed.data;
+
+    switch (message.type) {
+      case 'HEARTBEAT_ACK':
+        break;
+
+      case 'STREAM_READY':
+        s.log.info(`Stream ready with ${message.payload.bufferSize} frames buffered`);
+        postToMain({
+          type: 'STREAM_READY',
+          bufferSize: message.payload.bufferSize,
+        });
+        break;
+
+      case 'PLAYBACK_STARTED':
+        s.log.info(`Playback started on ${message.payload.speakerIp}`);
+        postToMain({
+          type: 'PLAYBACK_STARTED',
+          speakerIp: message.payload.speakerIp,
+          streamUrl: message.payload.streamUrl,
+        });
+        break;
+
+      case 'PLAYBACK_RESULTS': {
+        const results = message.payload.results;
+        const successful = results.filter((r) => r.success).length;
+        s.log.info(`Playback results: ${successful}/${results.length} speakers started`);
+        postToMain({
+          type: 'PLAYBACK_RESULTS',
+          results,
+        });
+        break;
+      }
+
+      case 'PLAYBACK_ERROR':
+        s.log.error(`Playback error: ${message.payload.message}`);
+        postToMain({
+          type: 'PLAYBACK_ERROR',
+          message: message.payload.message,
+        });
+        break;
+
+      case 'ERROR':
+        s.log.error(`Server error: ${message.payload.message}`);
+        postToMain({
+          type: 'ERROR',
+          message: message.payload.message,
+        });
+        break;
+
+      case 'BROWSER_CAPTURE_ERROR':
+        s.log.error(`Browser capture error: ${message.payload.error} (${message.payload.reason})`);
+        postToMain({
+          type: 'BROWSER_CAPTURE_ERROR',
+          error: message.payload.error,
+          reason: message.payload.reason,
+        });
+        break;
+
+      default:
+        break;
+    }
+  } catch {
+    // Ignore parse errors
+  }
+}
+
+/**
+ * Handles WebSocket close events.
+ * @param s - Worker state
+ * @param event - CloseEvent from WebSocket
+ */
+function handleWsClose(s: WorkerState, event: CloseEvent): void {
+  s.log.warn(`WebSocket closed: ${event.code} ${event.reason}`);
+  stopHeartbeat(s);
+  postToMain({
+    type: 'DISCONNECTED',
+    reason: event.reason || `Code ${event.code}`,
+  });
+}
+
+/**
+ * Handles WebSocket errors.
+ * @param s - Worker state
+ */
+function handleWsError(s: WorkerState): void {
+  s.log.error('WebSocket error');
+}
+
+/**
+ * Connects to the WebSocket and performs handshake.
+ * Sends a handshake message (encoder config), waits for HANDSHAKE_ACK with stream ID
+ * and STREAM_READY, then sets up persistent message handlers.
+ *
+ * @param s - Worker state (socket and streamId are set on success)
+ * @param wsUrl - The WebSocket URL to connect to
+ * @param handshake - The handshake message to send on connect
+ * @returns A promise resolving to the stream ID
+ */
+export async function connectWebSocket(
+  s: WorkerState,
+  wsUrl: string,
+  handshake: HandshakeMessage,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    s.log.info(`Connecting to WebSocket: ${wsUrl}`);
+
+    const ws = new WebSocket(wsUrl);
+    ws.binaryType = 'arraybuffer';
+    s.socket = ws;
+
+    const connectTimeout = setTimeout(() => {
+      ws.close();
+      reject(new Error('WebSocket connection timeout'));
+    }, WS_CONNECT_TIMEOUT_MS);
+
+    ws.onopen = () => {
+      clearTimeout(connectTimeout);
+      s.log.info('WebSocket connected, sending handshake...');
+
+      ws.send(JSON.stringify(handshake));
+
+      const handshakeTimeout = setTimeout(() => {
+        ws.close();
+        reject(new Error('Handshake timeout'));
+      }, HANDSHAKE_TIMEOUT_MS);
+
+      // Handle clean close during handshake
+      ws.onclose = (event: CloseEvent) => {
+        clearTimeout(handshakeTimeout);
+        reject(
+          new Error(`WebSocket closed during handshake: ${event.reason || `Code ${event.code}`}`),
+        );
+      };
+
+      const handshakeHandler = (event: MessageEvent) => {
+        if (typeof event.data !== 'string') return;
+
+        try {
+          const raw = JSON.parse(event.data);
+
+          // Skip broadcast events
+          if ('category' in raw || raw.type === 'INITIAL_STATE') return;
+
+          const parsed = WsMessageSchema.safeParse(raw);
+          if (!parsed.success) return;
+
+          const message = parsed.data;
+
+          if (message.type === 'HANDSHAKE_ACK') {
+            clearTimeout(handshakeTimeout);
+            ws.removeEventListener('message', handshakeHandler);
+            s.streamId = message.payload.streamId;
+            s.log.info(`Handshake complete, streamId: ${s.streamId}`);
+
+            startHeartbeat(s);
+
+            // Set up persistent message handlers bound to this state
+            ws.onmessage = (ev) => handleWsMessage(s, ev);
+            ws.onclose = (ev) => handleWsClose(s, ev);
+            ws.onerror = () => handleWsError(s);
+
+            resolve(message.payload.streamId);
+          } else if (message.type === 'ERROR') {
+            clearTimeout(handshakeTimeout);
+            ws.removeEventListener('message', handshakeHandler);
+            reject(new Error(message.payload.message));
+          }
+        } catch {
+          // Ignore parse errors during handshake
+        }
+      };
+
+      ws.addEventListener('message', handshakeHandler);
+    };
+
+    ws.onerror = () => {
+      clearTimeout(connectTimeout);
+      reject(new Error('WebSocket connection error'));
+    };
+  });
+}
+
+/**
+ * Sends a JSON message over the WebSocket.
+ * @param s - Worker state
+ * @param message - The message object to send
+ * @returns True if the message was sent, false otherwise
+ */
+export function sendWsMessage(s: WorkerState, message: object): boolean {
+  if (!s.socket || s.socket.readyState !== WebSocket.OPEN) {
+    return false;
+  }
+  s.socket.send(JSON.stringify(message));
+  return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Message Handling
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Handles messages common to all worker types: STOP, START_PLAYBACK, METADATA_UPDATE.
+ * Returns true if the message was handled, false if the worker should handle it.
+ *
+ * @param s - Worker state
+ * @param msg - Inbound message from main thread
+ * @param cleanup - Worker-specific cleanup function to call on STOP
+ * @returns True if the message was handled
+ */
+export function handleCommonMessage(
+  s: WorkerState,
+  msg: WorkerInboundMessage,
+  cleanup: () => void,
+): boolean {
+  switch (msg.type) {
+    case 'STOP':
+      cleanup();
+      return true;
+
+    case 'START_PLAYBACK': {
+      const { speakerIps, metadata, syncSpeakers = false, videoSyncEnabled } = msg;
+      sendWsMessage(s, {
+        type: 'START_PLAYBACK',
+        payload: { speakerIps, metadata, syncSpeakers, videoSyncEnabled },
+      });
+      return true;
+    }
+
+    case 'METADATA_UPDATE':
+      sendWsMessage(s, {
+        type: 'METADATA_UPDATE',
+        payload: msg.metadata,
+      });
+      return true;
+
+    default:
+      return false;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cleanup
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Dumps the metrics timeline and cleans up shared infrastructure state.
+ * Stops heartbeat, posts metrics dump, and closes WebSocket.
+ * Does NOT handle worker-specific cleanup (encoder, ring buffer, etc.).
+ *
+ * @param s - Worker state
+ */
+export function cleanupSharedState(s: WorkerState): void {
+  // Dump metrics timeline
+  if (s.metricTimeline.length > 0) {
+    postToMain({
+      type: 'METRICS_DUMP',
+      timeline: s.metricTimeline,
+    });
+    s.metricTimeline = [];
+  }
+
+  stopHeartbeat(s);
+
+  if (s.socket) {
+    // Send stop message in browser capture mode
+    if (s.browserCaptureMode && s.socket.readyState === WebSocket.OPEN) {
+      try {
+        s.socket.send(JSON.stringify({ type: 'STOP_BROWSER_CAPTURE' }));
+      } catch {
+        /* ignore send errors during shutdown */
+      }
+    }
+    s.socket.onopen = null;
+    s.socket.onclose = null;
+    s.socket.onerror = null;
+    s.socket.onmessage = null;
+    s.socket.close();
+    s.socket = null;
+  }
+
+  s.streamId = null;
+  s.policy = null;
+}

--- a/apps/extension/src/offscreen/worker-base.ts
+++ b/apps/extension/src/offscreen/worker-base.ts
@@ -108,8 +108,8 @@ export interface WorkerState {
   lastStatsTime: number;
 
   // Frame queue (quality mode backpressure decoupling)
-  /** Queue of encoded frames waiting to be sent. */
-  frameQueue: Uint8Array[];
+  /** Queue of encoded frames waiting to be sent. Frames must be ArrayBuffer-backed for WebSocket.send(). */
+  frameQueue: Uint8Array<ArrayBuffer>[];
   /** Total bytes currently in frameQueue. */
   frameQueueBytes: number;
   /** Count of frames dropped from queue due to overflow. */
@@ -285,7 +285,7 @@ function trimFrameQueue(s: WorkerState): void {
  * @param s - Worker state
  * @param frame - Encoded frame data to queue
  */
-export function enqueueFrame(s: WorkerState, frame: Uint8Array): void {
+export function enqueueFrame(s: WorkerState, frame: Uint8Array<ArrayBuffer>): void {
   s.frameQueue.push(frame);
   s.frameQueueBytes += frame.byteLength;
 

--- a/apps/extension/src/offscreen/worker-messages.ts
+++ b/apps/extension/src/offscreen/worker-messages.ts
@@ -14,16 +14,29 @@ import type { EncoderConfig, StreamMetadata } from '@thaumic-cast/protocol';
 // Inbound Messages (StreamSession → Worker)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Initializes the worker with buffer and encoder configuration. */
+/**
+ * Initializes the worker with buffer and encoder configuration.
+ *
+ * SAB fields are optional to allow alternative consumer worker implementations
+ * that do not use a SharedArrayBuffer ring buffer.
+ */
 export interface WorkerInitMessage {
   type: 'INIT';
-  sab: SharedArrayBuffer;
-  bufferSize: number;
-  bufferMask: number;
-  headerSize: number;
+  /** SharedArrayBuffer for ring buffer (SAB path only). */
+  sab?: SharedArrayBuffer;
+  /** Ring buffer capacity in samples (SAB path only). */
+  bufferSize?: number;
+  /** Ring buffer index mask (SAB path only). */
+  bufferMask?: number;
+  /** Ring buffer header size in Int32 elements (SAB path only). */
+  headerSize?: number;
   sampleRate: number;
   encoderConfig: EncoderConfig;
   wsUrl: string;
+  /** Pipeline mode. Defaults to 'passthrough' for backward compatibility. */
+  mode?: 'encode' | 'passthrough';
+  /** Number of interleaved Int16 samples per frame. Required when mode is 'encode'. */
+  frameSizeInterleaved?: number;
 }
 
 /** Stops the worker and cleans up resources. */
@@ -152,6 +165,38 @@ export interface WorkerStatsMessage {
   frameQueueOverflowDrops: number;
 }
 
+/** A single metrics snapshot captured during streaming. */
+export interface MetricSnapshot {
+  /** Timestamp relative to stream start (ms). */
+  t: number;
+  /** Ring buffer fill fraction (0–1). */
+  fill: number;
+  /** WebSocket buffered amount (bytes). */
+  wsBuf: number;
+  /** Underflow events in this interval. */
+  uf: number;
+  /** Producer dropped samples in this interval. */
+  pDrop: number;
+  /** Consumer dropped frames in this interval. */
+  cDrop: number;
+  /** Catch-up dropped samples in this interval. */
+  cuDrop: number;
+  /** Backpressure cycles in this interval. */
+  bp: number;
+  /** Frame queue size (frames). */
+  fq: number;
+  /** Frame queue bytes. */
+  fqB: number;
+  /** Frame queue overflow drops. */
+  fqDrop: number;
+}
+
+/** Full pipeline metrics timeline, posted on stream teardown. */
+export interface WorkerMetricsDumpMessage {
+  type: 'METRICS_DUMP';
+  timeline: MetricSnapshot[];
+}
+
 /** Union of all messages that can be sent from the worker. */
 export type WorkerOutboundMessage =
   | WorkerConnectedMessage
@@ -162,4 +207,5 @@ export type WorkerOutboundMessage =
   | WorkerPlaybackResultsMessage
   | WorkerPlaybackErrorMessage
   | WorkerBrowserCaptureErrorMessage
-  | WorkerStatsMessage;
+  | WorkerStatsMessage
+  | WorkerMetricsDumpMessage;

--- a/apps/extension/src/offscreen/worker-messages.ts
+++ b/apps/extension/src/offscreen/worker-messages.ts
@@ -17,8 +17,10 @@ import type { EncoderConfig, StreamMetadata } from '@thaumic-cast/protocol';
 /**
  * Initializes the worker with buffer and encoder configuration.
  *
- * SAB fields are optional to allow alternative consumer worker implementations
- * that do not use a SharedArrayBuffer ring buffer.
+ * Two pipeline modes:
+ * - **SAB path** (compressed codecs): `sab` is provided. Worker reads from SharedArrayBuffer.
+ * - **MSTP path** (PCM codec): `readable` is provided. Worker reads AudioData from
+ *   a transferred ReadableStream, performs Float32→Int16 conversion, sends via WebSocket.
  */
 export interface WorkerInitMessage {
   type: 'INIT';
@@ -37,6 +39,10 @@ export interface WorkerInitMessage {
   mode?: 'encode' | 'passthrough';
   /** Number of interleaved Int16 samples per frame. Required when mode is 'encode'. */
   frameSizeInterleaved?: number;
+  /** Transferred ReadableStream from MediaStreamTrackProcessor (MSTP path only). */
+  readable?: ReadableStream<AudioData>;
+  /** Number of audio channels (MSTP path only, default 2). */
+  channels?: number;
 }
 
 /** Stops the worker and cleans up resources. */

--- a/apps/extension/src/types/web-apis.d.ts
+++ b/apps/extension/src/types/web-apis.d.ts
@@ -53,6 +53,27 @@ interface ViewTransition {
   skipTransition(): void;
 }
 
+/**
+ * Initialization options for MediaStreamTrackProcessor.
+ * @see https://www.w3.org/TR/mediacapture-transform/#dom-mediastreamtrackprocessorinit
+ */
+interface MediaStreamTrackProcessorInit {
+  track: MediaStreamTrack;
+  /** Maximum number of frames to buffer before dropping oldest. */
+  maxBufferSize?: number;
+}
+
+/**
+ * Breaks a MediaStreamTrack into individual frames exposed as a ReadableStream.
+ * Chrome 94+, unflagged. Works on main thread and offscreen documents.
+ * @see https://www.w3.org/TR/mediacapture-transform/#mediastreamtrackprocessor
+ */
+declare class MediaStreamTrackProcessor {
+  /** Creates a processor that exposes frames from `init.track` as a ReadableStream. */
+  constructor(init: MediaStreamTrackProcessorInit);
+  readonly readable: ReadableStream<AudioData>;
+}
+
 interface Document {
   /**
    * Starts a view transition, capturing the current state and animating to the new state.


### PR DESCRIPTION
## What

Adds an alternative audio capture path for the PCM codec that uses `MediaStreamTrackProcessor` (MSTP) instead of `AudioContext` + `AudioWorklet` + `SharedArrayBuffer`.

Two commits:
- `refactor(extension): extract worker-base from audio-consumer` — factors shared worker infrastructure (WebSocket lifecycle, frame queue, backpressure/quality backoff, stats, metrics timeline) into a new `worker-base.ts`. Makes SAB fields optional on `WorkerInitMessage` so non-SAB consumers are possible.
- `feat(extension): add MSTP pipeline for PCM codec` — new `audio-relay.worker.ts` that reads `ReadableStream<AudioData>` (transferred from the main thread), performs fused interleave / NaN-safe clamp / TPDF dither / Int16 saturate, and sends fixed-size frames over WebSocket. `stream-session.ts` branches on codec in `setupAudioPipeline()`.

MSTP is used only for the PCM codec. Compressed codecs still use the AudioContext + AudioWorklet + SAB path because the encoder runs inside the worklet.

## Why

The AudioContext path crosses a clock domain between the MediaStream clock and the AudioContext clock. When those clocks drift, the AudioWorklet receives render quanta that include zero-filled blocks, audible as crackling. MSTP reads AudioData frames at the MediaStream's native rate, eliminating the crossing.

This is orthogonal to browser-wide WASAPI capture (#90, already merged). WASAPI bypasses Chrome's capture entirely for users running the desktop app; MSTP is a cleaner fallback for the tab-capture path.

`keepTabAudible` in MSTP mode uses a low-volume `<audio>` element rather than an AudioContext gain node, so it doesn't reintroduce the clock-domain crossing we just removed.

## How to Test

- `bun run build:extension` should build cleanly.
- Load the extension, start a tab capture with the PCM codec at stereo and then at mono. Confirm audio plays on the Sonos side without crackling, and frame rate / sample count match the configured frame duration.
- Switch to a compressed codec (Opus) and confirm the AudioContext + AudioWorklet path is unchanged.
- Toggle `keepTabAudible` in MSTP mode; verify Chrome does not throttle the capturing tab.
- Start a browser-wide capture session to confirm the WASAPI path is unaffected.

## Related Issue

None.

---

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)