### PR TITLE
fix(extension): route WASAPI browser capture to audio-consumer worker regardless of codec

### DIFF
--- a/.changeset/fix-wasapi-pcm-worker-selection.md
+++ b/.changeset/fix-wasapi-pcm-worker-selection.md
@@ -1,0 +1,9 @@
+---
+'@thaumic-cast/extension': patch
+---
+
+Fix "Session init timed out" when casting with WASAPI browser capture and the PCM codec
+
+After the MSTP PCM pipeline landed, `startWorker()` selected the worker purely by codec: PCM → `audio-relay.worker.ts`, everything else → `audio-consumer.worker.ts`. But `audio-relay.worker.ts` only knows how to consume a transferred `ReadableStream<AudioData>` from `MediaStreamTrackProcessor` — it has no handler for `INIT_BROWSER_CAPTURE`. So when a user enabled WASAPI browser-wide capture with the PCM codec, the offscreen document spawned the MSTP worker, posted `INIT_BROWSER_CAPTURE`, and the message was silently dropped. The WebSocket never opened, the connection promise never resolved, and init timed out.
+
+Worker selection now mirrors the capture-mode branching already present further down in `startWorker()`: the MSTP relay is used only for `captureMode === 'tab'` + PCM, and `audio-consumer.worker.ts` handles all browser-capture sessions regardless of codec. The latter already implements the WS-lifecycle-only browser-capture path, so no worker logic needs to move.

--- a/apps/extension/src/offscreen/stream-session.ts
+++ b/apps/extension/src/offscreen/stream-session.ts
@@ -564,8 +564,10 @@ export class StreamSession {
   private async startWorker(): Promise<void> {
     const wsUrl = this.baseUrl.replace(/^http/, 'ws') + '/ws';
 
-    // Spawn codec-appropriate worker
-    if (this.encoderConfig.codec === 'pcm') {
+    // Spawn codec-appropriate worker. The MSTP relay only applies to tab
+    // capture — browser/WASAPI capture has no MediaStream and must use the
+    // audio-consumer worker, which handles INIT_BROWSER_CAPTURE.
+    if (this.captureMode === 'tab' && this.encoderConfig.codec === 'pcm') {
       this.consumerWorker = new Worker(new URL('./audio-relay.worker.ts', import.meta.url), {
         type: 'module',
       });


### PR DESCRIPTION
## What

In `apps/extension/src/offscreen/stream-session.ts`, gate MSTP worker selection on `captureMode === 'tab'` so browser/WASAPI capture always spawns `audio-consumer.worker.ts`, regardless of codec. Adds a `patch` changeset for `@thaumic-cast/extension`.

## Why

After the MSTP PCM pipeline landed, `startWorker()` selected the worker purely by codec:

- codec `pcm` → `audio-relay.worker.ts` (the new MSTP relay)
- anything else → `audio-consumer.worker.ts`

But `audio-relay.worker.ts` is purpose-built around consuming a transferred `ReadableStream<AudioData>` from `MediaStreamTrackProcessor`. It has no handler for `INIT_BROWSER_CAPTURE` — that handler lives in `audio-consumer.worker.ts:941` and sets `browserCaptureMode = true` / sends `START_BROWSER_CAPTURE` over the WS.

So with WASAPI browser capture enabled **and** the PCM codec selected, the offscreen document spawned the MSTP worker, posted `INIT_BROWSER_CAPTURE`, and the message was silently dropped. The WebSocket never opened, the connection promise never resolved, and init hit `INIT_TIMEOUT_MS`. User-visible failure:

```
[Offscreen] Failed to initialize session Error: Session init timed out
[Background] Cast failed: Offscreen message timed out
```

MSTP has no purpose in browser capture — there is no MediaStream to process because the desktop app captures audio via WASAPI. The correct fix is to scope the MSTP relay to `captureMode === 'tab'`, matching the capture-mode branching that already exists further down in `startWorker()` when posting the INIT message.

## How to Test

1. Build the extension: `bun run build` (or the equivalent workspace script).
2. Load the `apps/extension/dist` unpacked extension in Chrome on Windows.
3. In extension options, set codec to PCM and toggle **Browser-wide Capture (WASAPI)** on.
4. Start a cast to any Sonos target.
5. Expected: cast starts cleanly, audio streams, no `Session init timed out` in the offscreen console and no `Offscreen message timed out` in the background console.
6. Regression check: toggle WASAPI off and cast on PCM via tab capture — MSTP path still used, no crackling.
7. Regression check: toggle WASAPI on with a compressed codec (AAC/FLAC/Vorbis) — still works as before.

## Related Issue

None — caught while testing `main` against the pre-MSTP WASAPI worktree.

---

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)