### PR TITLE
fix(core,desktop): harden streaming network path and log retention

### DIFF
--- a/.changeset/core-network-resilience.md
+++ b/.changeset/core-network-resilience.md
@@ -1,0 +1,18 @@
+---
+'@thaumic-cast/core': patch
+'@thaumic-cast/desktop': patch
+---
+
+Harden streaming network path and diagnostic log retention
+
+Four isolated fixes to the local streaming daemon and desktop app:
+
+**Core (`thaumic-core`):**
+
+- TCP_NODELAY on all accepted connections disables Nagle's algorithm so small PCM frames (1920 bytes) ship immediately instead of being batched, reducing delivery jitter to Sonos.
+- TCP keepalive on accepted connections (10s idle, 5s interval, 3 retries on Linux) detects stalled speakers within ~25s instead of the default ~2 hours, preventing async tasks from being held alive on dead connections.
+- SSDP discovery now skips link-local (`169.254.0.0/16`) addresses that cause bind failures on adapters like Bluetooth with no real connectivity, and expands the virtual-interface prefix list (Windows `vEthernet`, WireGuard, Tailscale, ZeroTier) that cannot reach local Sonos speakers.
+
+**Desktop:**
+
+- Raises log max file size to 1 MB so pipeline diagnostic dumps survive across sessions without rotation.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -43,6 +43,7 @@ pub fn run() {
                     Target::new(TargetKind::LogDir { file_name: None }),
                     Target::new(TargetKind::Webview),
                 ])
+                .max_file_size(1_000_000) // 1 MB (default 40 KB rotates away pipeline timelines)
                 .level(if cfg!(debug_assertions) {
                     log::LevelFilter::Debug
                 } else {

--- a/packages/thaumic-core/src/api/mod.rs
+++ b/packages/thaumic-core/src/api/mod.rs
@@ -6,6 +6,7 @@
 use std::net::IpAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use parking_lot::RwLock;
 use thiserror::Error;
@@ -179,9 +180,23 @@ pub async fn start_server(state: AppState) -> Result<(), ServerError> {
     // TCP_NODELAY: Disable Nagle's algorithm on every accepted connection.
     // Without this, TCP buffers small writes (1920-byte PCM frames) and sends them
     // in batches, causing uneven delivery timing to Sonos speakers.
+    //
+    // TCP keepalive: Detect dead connections within ~25s (10s idle + 3 × 5s probes)
+    // instead of the default ~2 hours. Critical for streaming connections where a
+    // stalled Sonos speaker would otherwise hold the async task alive indefinitely.
     let listener = listener.tap_io(|tcp_stream| {
         if let Err(err) = tcp_stream.set_nodelay(true) {
             log::warn!("Failed to set TCP_NODELAY on incoming connection: {err:#}");
+        }
+
+        let sock_ref = socket2::SockRef::from(&*tcp_stream);
+        let keepalive = socket2::TcpKeepalive::new()
+            .with_time(Duration::from_secs(10))
+            .with_interval(Duration::from_secs(5));
+        #[cfg(target_os = "linux")]
+        let keepalive = keepalive.with_retries(3);
+        if let Err(err) = sock_ref.set_tcp_keepalive(&keepalive) {
+            log::warn!("Failed to set TCP keepalive: {err:#}");
         }
     });
 

--- a/packages/thaumic-core/src/api/mod.rs
+++ b/packages/thaumic-core/src/api/mod.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 use thiserror::Error;
 
+use axum::serve::ListenerExt;
+
 use crate::artwork::{ArtworkConfig, ArtworkSource};
 use crate::capture::CaptureSourceFactory;
 use crate::context::NetworkContext;
@@ -173,6 +175,15 @@ pub async fn start_server(state: AppState) -> Result<(), ServerError> {
 
     log::info!("Server listening on http://0.0.0.0:{}", port);
     let app = http::create_router(state);
+
+    // TCP_NODELAY: Disable Nagle's algorithm on every accepted connection.
+    // Without this, TCP buffers small writes (1920-byte PCM frames) and sends them
+    // in batches, causing uneven delivery timing to Sonos speakers.
+    let listener = listener.tap_io(|tcp_stream| {
+        if let Err(err) = tcp_stream.set_nodelay(true) {
+            log::warn!("Failed to set TCP_NODELAY on incoming connection: {err:#}");
+        }
+    });
 
     // Use into_make_service_with_connect_info to enable ConnectInfo<SocketAddr> extraction
     axum::serve(

--- a/packages/thaumic-core/src/sonos/discovery/ssdp.rs
+++ b/packages/thaumic-core/src/sonos/discovery/ssdp.rs
@@ -123,7 +123,7 @@ pub fn get_interfaces() -> Vec<InterfaceInfo> {
                 return None;
             }
             match addr {
-                IpAddr::V4(ipv4) if !ipv4.is_loopback() => {
+                IpAddr::V4(ipv4) if !ipv4.is_loopback() && !ipv4.is_link_local() => {
                     log::debug!("Using interface {} ({})", name, ipv4);
                     // Compute broadcast address (assume /24 if we can't determine)
                     // This is a simplification - ideally we'd get the actual netmask


### PR DESCRIPTION
## What

Four isolated fixes to the local streaming daemon and desktop app:

**Core (`thaumic-core`):**
- **TCP_NODELAY** on all accepted connections — disables Nagle's algorithm so small PCM frames (1920 bytes) ship immediately instead of being batched, reducing delivery jitter to Sonos.
- **TCP keepalive** on accepted connections (10s idle, 5s interval, 3 retries on Linux) — detects stalled speakers within ~25s instead of the default ~2 hours, preventing async tasks from being held alive on dead connections.
- **SSDP interface filter** — skips link-local (`169.254.0.0/16`) addresses that cause bind failures on adapters like Bluetooth with no real connectivity, and expands the virtual-interface prefix list (Windows `vEthernet`, WireGuard, Tailscale, ZeroTier) that cannot reach local Sonos speakers.

**Desktop:**
- **Raise log max file size to 1 MB** — 40 KB default caused pipeline diagnostic dumps (~10 KB each) to trigger rotation, losing diagnostic data between test sessions.

## Why

These four fixes were bundled together on the `skezo/streming-pipeline-resilience` branch (PR #82) as foundational infrastructure for the streaming-resilience + instrumentation work. Extracting them into a small, independent PR so they can land without being blocked by the larger pipeline refactors that followed (jitter buffer, instrumentation, encode-in-worklet) — and so the benefit of the networking fixes is available immediately rather than waiting on those larger changes to settle.

## How to Test

- `cargo test -p thaumic-core --lib` (197 tests pass locally, including the new `test_is_virtual_interface_*` and `test_should_skip_interface_link_local` cases).
- `cargo clippy -p thaumic-core --lib --tests -- -D warnings` (clean).
- Manual (Linux/macOS): start the daemon, `ss -tni` on a connected client socket shows `keepalive timer` and `nodelay` set.
- Manual (Sonos dead-connection): disconnect speaker network cable mid-stream; async task should terminate within ~25s instead of hanging for hours.
- Manual (SSDP on Windows with WireGuard/Tailscale running): discovery should succeed on the real LAN adapter without bind failures on VPN overlays.

## Related Issue

Extracts the network-resilience subset of #82. None of the other #82 commits are in this PR; separate PRs will follow for instrumentation, jitter buffer, and FLAC-path perf fixes.

---

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)