### PR TITLE
fix(extension): default keepTabAudible on + declare AUDIO_PLAYBACK reason

### DIFF
--- a/.changeset/ext-keep-tab-audible-default.md
+++ b/.changeset/ext-keep-tab-audible-default.md
@@ -1,0 +1,9 @@
+---
+'@thaumic-cast/extension': patch
+---
+
+Default `keepTabAudible` on and declare AUDIO_PLAYBACK intent for the offscreen document
+
+Flips the `keepTabAudible` setting default from `false` to `true` so Chrome treats the offscreen document as an active audio page, preventing AudioContext suspension and aggressive timer throttling on constrained devices. Also adds `chrome.offscreen.Reason.AUDIO_PLAYBACK` alongside `USER_MEDIA` so the offscreen document's lifecycle intent matches what it actually does.
+
+Users who had previously toggled this setting off manually will keep their preference (only the default changes).

--- a/apps/extension/src/background/offscreen-manager.ts
+++ b/apps/extension/src/background/offscreen-manager.ts
@@ -97,8 +97,8 @@ export async function ensureOffscreen(): Promise<void> {
   offscreenCreationPromise = chrome.offscreen
     .createDocument({
       url: 'src/offscreen/offscreen.html',
-      reasons: [chrome.offscreen.Reason.USER_MEDIA],
-      justification: 'Capture and encode tab audio for streaming to Sonos',
+      reasons: [chrome.offscreen.Reason.USER_MEDIA, chrome.offscreen.Reason.AUDIO_PLAYBACK],
+      justification: 'Capture tab audio and maintain audio processing to prevent throttling',
     })
     .then(() => {
       offscreenCreationPromise = null;

--- a/apps/extension/src/lib/settings.ts
+++ b/apps/extension/src/lib/settings.ts
@@ -190,7 +190,7 @@ export const ExtensionSettingsSchema = z.object({
 
   // Keep tab audible: plays audio at very low volume to prevent Chrome throttling
   // When enabled, Chrome sees the tab as "playing audio" and won't throttle it
-  keepTabAudible: z.boolean().default(false),
+  keepTabAudible: z.boolean().default(true),
 
   // Sync speakers: groups multiple speakers for synchronized playback (default: false)
   syncSpeakers: z.boolean().default(false),
@@ -219,7 +219,7 @@ const DEFAULT_EXTENSION_SETTINGS: ExtensionSettings = {
     frameDurationMs: FRAME_DURATION_MS_DEFAULT,
   },
   videoSyncEnabled: false,
-  keepTabAudible: false,
+  keepTabAudible: true,
   syncSpeakers: false,
   captureMode: 'tab' as const,
 };


### PR DESCRIPTION
## What

Two small, coupled changes to the extension's offscreen-document lifecycle:

- Flip `keepTabAudible` default from `false` → `true` so Chrome treats the offscreen document as an active audio page, preventing AudioContext suspension and aggressive timer throttling on constrained devices.
- Add `chrome.offscreen.Reason.AUDIO_PLAYBACK` alongside `USER_MEDIA` when creating the offscreen document so the declared lifecycle intent matches what the document actually does.

Users who previously toggled the setting off manually keep their preference — only the default changes.

## Why

On 2-core Chrome targets (e.g. Surface Go) the offscreen document has been getting throttled mid-stream, which shows up downstream as zero-filled audio blocks and frame-drop clusters. Declaring `AUDIO_PLAYBACK` and keeping the tab audible by default are Chrome's canonical signals that this document needs to stay responsive, so turning them on out of the box gets every user the anti-throttling protection without requiring them to discover and flip a setting.

Independent of the larger pipeline work: it does not depend on the instrumentation / jitter-buffer / encode-in-worklet changes that also sat on `skezo/streming-pipeline-resilience`, so it can ship ahead of them.

## How to Test

- Install the extension from this branch, start a stream, and confirm `keepTabAudible` is toggled on in Advanced Settings without any prior setup.
- In `chrome://extensions` → service worker → inspect offscreen document — confirm both `USER_MEDIA` and `AUDIO_PLAYBACK` appear in the document's declared reasons.
- On a constrained 2-core device, run a long stream (~10 min) with a non-focused browser window and verify no AudioContext suspension events appear in the console.
- Verify a user who had previously set `keepTabAudible: false` in storage sees that choice preserved (Zod default does not override stored values).

## Related Issue

Extracts the `keepTabAudible` default fix from #82 (superseded). Lands independently of the instrumentation / jitter-buffer / FLAC-drain follow-ups.

---

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)