### PR TITLE
feat(core): add pipeline instrumentation timeline for post-session diagnostics

### DIFF
--- a/.changeset/core-pipeline-instrumentation.md
+++ b/.changeset/core-pipeline-instrumentation.md
@@ -1,0 +1,11 @@
+---
+'@thaumic-cast/core': minor
+---
+
+Add core-side pipeline instrumentation timeline for post-session diagnostics
+
+`LoggingStreamGuard` now accumulates per-tick pipeline snapshots (receive jitter from `StreamState`, cadence buffer health, HTTP delivery stats) and serializes them alongside the existing stream summary on drop. Snapshots land in a `Mutex`-guarded buffer so a mid-loop cadence abort (typical when Sonos closes HTTP) preserves the timeline instead of losing it.
+
+The cadence stream holds `Weak<StreamState>` rather than `Arc` so instrumentation does not prolong stream lifetime after cleanup; snapshots are skipped when the upgrade fails.
+
+Complements the extension-side metric timeline already shipped with the MSTP worker infrastructure — the two halves now cover all six pipeline stages end-to-end.

--- a/packages/thaumic-core/src/api/stream.rs
+++ b/packages/thaumic-core/src/api/stream.rs
@@ -10,6 +10,7 @@
 
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -157,6 +158,7 @@ pub(super) async fn stream_audio(
                 audio_format: stream_state.audio_format,
                 prefill_frames,
             },
+            Some(Arc::downgrade(&stream_state)),
             Some((
                 Arc::clone(&stream_state),
                 epoch_candidate,
@@ -264,7 +266,12 @@ pub(super) async fn stream_audio(
     let final_stream: AudioStream =
         Box::pin(inner_stream.map(move |res: Result<Bytes, std::io::Error>| {
             match &res {
-                Ok(_) => guard_for_frames.record_frame(),
+                Ok(bytes) => {
+                    guard_for_frames.record_frame();
+                    guard_for_frames
+                        .bytes_sent
+                        .fetch_add(bytes.len() as u64, Ordering::Relaxed);
+                }
                 Err(e) => guard_for_frames.record_error(&e.to_string()),
             }
             res

--- a/packages/thaumic-core/src/stream/cadence.rs
+++ b/packages/thaumic-core/src/stream/cadence.rs
@@ -13,6 +13,7 @@ use std::time::{Duration, Instant};
 use async_stream::stream;
 use bytes::Bytes;
 use futures::Stream;
+use serde::Serialize;
 use tokio::sync::broadcast;
 use tokio::time::{interval, Instant as TokioInstant, MissedTickBehavior};
 
@@ -59,6 +60,45 @@ pub(crate) struct CadenceStats {
     pub frames_dropped: u64,
 }
 
+/// Maximum pipeline snapshots to keep (300 entries × ~1s = ~5 minutes).
+const MAX_PIPELINE_SNAPSHOTS: usize = 300;
+
+/// Receive jitter window for a pipeline snapshot.
+#[derive(Serialize)]
+struct ReceiveWindow {
+    frames_received: u64,
+    min_gap_ms: u64,
+    max_gap_ms: u64,
+    gaps_over_threshold: u64,
+}
+
+/// Cadence buffer window for a pipeline snapshot.
+#[derive(Serialize)]
+struct CadenceWindow {
+    queue_len: usize,
+    silence_events: u64,
+    silence_frames: u64,
+    drops: u64,
+}
+
+/// HTTP delivery window for a pipeline snapshot.
+#[derive(Serialize)]
+struct DeliveryWindow {
+    frames_sent: u64,
+    bytes_per_second: u64,
+    max_gap_ms: u64,
+    gaps_over_threshold: u64,
+}
+
+/// Timestamped pipeline health snapshot, captured every ~1s in the cadence loop.
+#[derive(Serialize)]
+struct PipelineSnapshot {
+    elapsed_ms: u64,
+    receive: ReceiveWindow,
+    cadence: CadenceWindow,
+    delivery: DeliveryWindow,
+}
+
 /// Wrapper that logs HTTP audio stream lifecycle and tracks delivery timing.
 ///
 /// Delivery gap tracking uses lock-free atomics on the hot path.
@@ -77,6 +117,14 @@ pub struct LoggingStreamGuard {
     first_error: parking_lot::Mutex<Option<String>>,
     /// Cadence-specific stats, set once when the cadence stream ends.
     cadence_stats: OnceLock<CadenceStats>,
+    /// Total bytes delivered to HTTP client (for throughput calculation).
+    pub(crate) bytes_sent: AtomicU64,
+    /// Per-interval max delivery gap in ms (swapped to 0 on each snapshot).
+    interval_max_gap_ms: AtomicU64,
+    /// Pipeline timeline, updated periodically by the cadence stream.
+    /// Uses Mutex (not OnceLock) because the cadence stream may be dropped
+    /// mid-loop when Sonos closes HTTP, before it can write a final value.
+    pipeline_timeline: parking_lot::Mutex<VecDeque<PipelineSnapshot>>,
 }
 
 impl LoggingStreamGuard {
@@ -97,6 +145,9 @@ impl LoggingStreamGuard {
             gaps_over_threshold: AtomicU64::new(0),
             first_error: parking_lot::Mutex::new(None),
             cadence_stats: OnceLock::new(),
+            bytes_sent: AtomicU64::new(0),
+            interval_max_gap_ms: AtomicU64::new(0),
+            pipeline_timeline: parking_lot::Mutex::new(VecDeque::new()),
         }
     }
 
@@ -111,6 +162,8 @@ impl LoggingStreamGuard {
             let gap_ms = now_nanos.saturating_sub(prev_nanos) / 1_000_000;
 
             self.max_gap_ms.fetch_max(gap_ms, Ordering::Relaxed);
+            self.interval_max_gap_ms
+                .fetch_max(gap_ms, Ordering::Relaxed);
 
             if gap_ms > DELIVERY_GAP_THRESHOLD_MS {
                 self.gaps_over_threshold.fetch_add(1, Ordering::Relaxed);
@@ -138,6 +191,15 @@ impl LoggingStreamGuard {
     /// Stores cadence stream statistics. Called once when the cadence stream ends.
     pub(crate) fn set_cadence_stats(&self, stats: CadenceStats) {
         let _ = self.cadence_stats.set(stats);
+    }
+
+    /// Appends a snapshot to the pipeline timeline (called every ~1s from cadence stream).
+    fn push_pipeline_snapshot(&self, snapshot: PipelineSnapshot) {
+        let mut timeline = self.pipeline_timeline.lock();
+        timeline.push_back(snapshot);
+        if timeline.len() > MAX_PIPELINE_SNAPSHOTS {
+            timeline.pop_front();
+        }
     }
 }
 
@@ -181,10 +243,23 @@ impl Drop for LoggingStreamGuard {
             .map(|s| format!(", frames_dropped={}", s.frames_dropped))
             .unwrap_or_default();
 
+        let timeline = self.pipeline_timeline.lock();
+        let timeline_json = if timeline.is_empty() {
+            String::new()
+        } else {
+            serde_json::to_string(&*timeline).unwrap_or_default()
+        };
+        drop(timeline);
+        let timeline_info = if timeline_json.is_empty() {
+            String::new()
+        } else {
+            format!(", pipeline_timeline={}", timeline_json)
+        };
+
         if let Some(ref err) = *first_error {
             log::warn!(
                 "[Stream] HTTP stream ended with error{}: stream={}, client={}, frames_sent={}, \
-                 max_gap={}ms, gaps_over_{}ms={}, final_gap={}ms{}{}, error={}",
+                 max_gap={}ms, gaps_over_{}ms={}, final_gap={}ms{}{}{}, error={}",
                 stalled_suffix,
                 self.stream_id,
                 self.client_ip,
@@ -195,12 +270,13 @@ impl Drop for LoggingStreamGuard {
                 final_gap_ms,
                 silence_info,
                 dropped_info,
+                timeline_info,
                 err
             );
         } else {
             log::info!(
                 "[Stream] HTTP stream ended normally{}: stream={}, client={}, frames_sent={}, \
-                 max_gap={}ms, gaps_over_{}ms={}, final_gap={}ms{}{}",
+                 max_gap={}ms, gaps_over_{}ms={}, final_gap={}ms{}{}{}",
                 stalled_suffix,
                 self.stream_id,
                 self.client_ip,
@@ -210,7 +286,8 @@ impl Drop for LoggingStreamGuard {
                 gaps_over_threshold,
                 final_gap_ms,
                 silence_info,
-                dropped_info
+                dropped_info,
+                timeline_info
             );
         }
     }
@@ -321,6 +398,7 @@ pub fn create_wav_stream_with_cadence(
     mut rx: broadcast::Receiver<Bytes>,
     guard: Arc<LoggingStreamGuard>,
     config: CadenceConfig,
+    stream_state: Option<std::sync::Weak<StreamState>>,
     epoch_hook: Option<(Arc<StreamState>, Option<Instant>, Instant, IpAddr)>,
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> {
     stream! {
@@ -361,6 +439,13 @@ pub fn create_wav_stream_with_cadence(
 
         // One-shot epoch hook: fires on the first real audio frame, then consumed
         let mut epoch_hook = epoch_hook;
+
+        // Pipeline snapshot state
+        let mut tick_count: u64 = 0;
+        let mut prev_delivery_frames: u64 = 0;
+        let mut prev_delivery_bytes: u64 = 0;
+        let mut prev_delivery_gaps: u64 = 0;
+        let mut prev_snapshot_ms: u64 = 0;
 
         loop {
             // Exit when channel closed AND queue drained
@@ -443,6 +528,63 @@ pub fn create_wav_stream_with_cadence(
                                 }
                             }
                         }
+                    }
+
+                    // Pipeline snapshot every ~50 ticks (~1s at 20ms cadence)
+                    tick_count += 1;
+                    if tick_count % 50 == 0 {
+                        let elapsed_ms = guard.reference_time.elapsed().as_millis() as u64;
+
+                        // Receive window: snapshot and reset from StreamState
+                        // Uses Weak ref - if StreamState was dropped (channel closing), skip
+                        let receive = if let Some(ss) = stream_state.as_ref().and_then(|w| w.upgrade()) {
+                            let rs = ss.snapshot_and_reset_receive_stats();
+                            ReceiveWindow {
+                                frames_received: rs.frames_received,
+                                min_gap_ms: if rs.min_gap_ms == u64::MAX { 0 } else { rs.min_gap_ms },
+                                max_gap_ms: rs.max_gap_ms,
+                                gaps_over_threshold: rs.gaps_over_threshold,
+                            }
+                        } else {
+                            ReceiveWindow { frames_received: 0, min_gap_ms: 0, max_gap_ms: 0, gaps_over_threshold: 0 }
+                        };
+
+                        // Cadence window: current counters (cumulative, not reset)
+                        let cadence_window = CadenceWindow {
+                            queue_len: queue.len(),
+                            silence_events,
+                            silence_frames,
+                            drops: frames_dropped,
+                        };
+
+                        // Delivery window: deltas from guard atomics
+                        let cur_frames = guard.frames_sent.load(Ordering::Relaxed);
+                        let cur_bytes = guard.bytes_sent.load(Ordering::Relaxed);
+                        let cur_gaps = guard.gaps_over_threshold.load(Ordering::Relaxed);
+                        let interval_max = guard.interval_max_gap_ms.swap(0, Ordering::Relaxed);
+
+                        let delta_bytes = cur_bytes.saturating_sub(prev_delivery_bytes);
+                        let interval_ms = elapsed_ms.saturating_sub(prev_snapshot_ms);
+                        let bytes_per_second = if interval_ms > 0 { delta_bytes * 1000 / interval_ms } else { 0 };
+
+                        let delivery = DeliveryWindow {
+                            frames_sent: cur_frames.saturating_sub(prev_delivery_frames),
+                            bytes_per_second,
+                            max_gap_ms: interval_max,
+                            gaps_over_threshold: cur_gaps.saturating_sub(prev_delivery_gaps),
+                        };
+
+                        prev_delivery_frames = cur_frames;
+                        prev_delivery_bytes = cur_bytes;
+                        prev_delivery_gaps = cur_gaps;
+                        prev_snapshot_ms = elapsed_ms;
+
+                        guard.push_pipeline_snapshot(PipelineSnapshot {
+                            elapsed_ms,
+                            receive,
+                            cadence: cadence_window,
+                            delivery,
+                        });
                     }
                 }
 
@@ -579,6 +721,7 @@ mod tests {
             guard,
             test_config(),
             None,
+            None,
         ));
 
         // Queue some frames before the first tick
@@ -623,6 +766,7 @@ mod tests {
             guard,
             test_config(),
             None,
+            None,
         ));
 
         // Don't send any frames - queue will be empty
@@ -666,6 +810,7 @@ mod tests {
             rx,
             guard,
             test_config(),
+            None,
             None,
         ));
 
@@ -719,6 +864,7 @@ mod tests {
             guard,
             test_config(),
             None,
+            None,
         ));
 
         // Send 12 frames (queue_size + 2), should drop 2 oldest
@@ -764,6 +910,7 @@ mod tests {
             guard,
             test_config(),
             None,
+            None,
         ));
 
         // Overflow queue by TEST_QUEUE_SIZE + 3 frames
@@ -808,6 +955,7 @@ mod tests {
             rx,
             guard,
             test_config(),
+            None,
             None,
         ));
 
@@ -867,6 +1015,7 @@ mod tests {
             rx,
             guard,
             test_config(),
+            None,
             None,
         ));
 

--- a/packages/thaumic-core/src/stream/cadence.rs
+++ b/packages/thaumic-core/src/stream/cadence.rs
@@ -565,7 +565,7 @@ pub fn create_wav_stream_with_cadence(
 
                         let delta_bytes = cur_bytes.saturating_sub(prev_delivery_bytes);
                         let interval_ms = elapsed_ms.saturating_sub(prev_snapshot_ms);
-                        let bytes_per_second = if interval_ms > 0 { delta_bytes * 1000 / interval_ms } else { 0 };
+                        let bytes_per_second = (delta_bytes * 1000).checked_div(interval_ms).unwrap_or(0);
 
                         let delivery = DeliveryWindow {
                             frames_sent: cur_frames.saturating_sub(prev_delivery_frames),


### PR DESCRIPTION
## What

Adds a core-side pipeline instrumentation timeline to the streaming daemon. On each ~1s cadence tick, a `PipelineSnapshot` is pushed into a `Mutex<VecDeque<PipelineSnapshot>>` on `LoggingStreamGuard`, capturing:

- **Receive-side** (from `StreamState`): WebSocket frame arrival cadence and max inter-arrival gap.
- **Cadence-side**: queue depth, underrun events, prefill state.
- **Delivery-side**: bytes sent and max inter-write gap to the Sonos HTTP stream.

On `Drop`, the guard serializes the full timeline as JSON alongside the existing stream summary line — even when the cadence stream is aborted mid-loop (typical when Sonos closes the HTTP connection), because we flush to the Mutex each tick rather than deferring to a post-loop `OnceLock` that never fires in that path.

The cadence stream holds `Weak<StreamState>` rather than `Arc` so instrumentation does not keep the broadcast `Sender` alive past registry cleanup; when the upgrade fails, we simply skip that tick's snapshot.

All hot-path work is numeric counters + periodic array pushes — no per-frame logging or string formatting.

## Why

On constrained devices (e.g. 2-core Surface Go) streams degrade in specific ways that are invisible from a single summary line: one session's ring buffer overflows, another's cadence queue starves, another's HTTP writes clump under network jitter. Without a timeline we cannot tell which stage failed first, so we can't prioritize the right fix.

Complements the extension-side `MetricSnapshot` timeline (ring buffer / encoder / WebSocket) that already ships with the MSTP worker infrastructure. The two halves together now cover all six pipeline stages end-to-end. Originally on `skezo/streming-pipeline-resilience` (#82) as three commits (`595c160` + `d61bd19` + `211abcb`); extracting the core-side subset because the extension-side plumbing already landed via MSTP (PR #96), so only Rust changes are net-new.

## How to Test

- `cargo test -p thaumic-core --lib` (197 pass locally).
- `cargo clippy -p thaumic-core --lib --tests -- -D warnings` (clean).
- Start a stream and let it run for ~30s, then stop it. The daemon summary log at stream-end should now include a `pipeline_timeline=[...]` field with ~30 snapshots. Parse as JSON to inspect per-tick receive/cadence/delivery stats.
- Kill a stream abruptly (pull the Sonos network cable mid-playback). The timeline should still be written — this is the scenario the `Mutex` + `Weak<StreamState>` design targets, where a `OnceLock` would have lost the data.
- On a constrained device, run a session long enough to observe degradation; the timeline should reveal whether receive jitter, cadence underrun, or HTTP-write gap appears first.

## Related Issue

Extracts the core-side subset of #82. Depends on MSTP (#96) already merged — without MSTP's `MetricSnapshot` / `WorkerMetricsDumpMessage` / deferred-terminate plumbing in place, the extension side has no way to dump its own half of the timeline. Jitter-buffer PR will build on top of this for `target_depth` visibility.

---

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)