### PR TITLE
perf(extension): eliminate scheduling bottleneck in FLAC consumer drain loop

### DIFF
--- a/.changeset/ext-flac-drain-perf.md
+++ b/.changeset/ext-flac-drain-perf.md
@@ -1,0 +1,9 @@
+---
+'@thaumic-cast/extension': patch
+---
+
+Eliminate scheduling bottleneck in the FLAC consumer worker drain loop
+
+Removes the 4ms `PROCESS_BUDGET_MS` time cap so the consumer drains every available ring-buffer sample per scheduling slot. On thermally-throttled devices where Chrome reschedules the worker with 100-280ms gaps, the old cap caused a compounding throughput deficit (~12% frame loss on 2-core targets). Adds a matching forward clamp on `nextFrameDueTime` so burst-processed audio time does not register as "ahead of schedule" and yield away the benefit.
+
+Only affects compressed codec paths that still run through `audio-consumer.worker` (FLAC). The PCM-via-MSTP path uses `audio-relay.worker` and is unaffected.

--- a/apps/extension/src/offscreen/audio-consumer.worker.ts
+++ b/apps/extension/src/offscreen/audio-consumer.worker.ts
@@ -102,18 +102,6 @@ function frameSizeToMs(frameSizeSamples: number, sampleRate: number): number {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Worker-Specific Constants
-// ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Time budget for processing frames per wake cycle (ms).
- * Stay under typical browser timer quantum (~4ms) to avoid timer coalescing issues.
- * Per web.dev/articles/audio-scheduling: setTimeout can be skewed by 10ms+ from
- * layout, rendering, and GC, so we busy-poll within budget instead.
- */
-const PROCESS_BUDGET_MS = 4;
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Underflow Ramp Constants
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -571,8 +559,16 @@ function isEncoderBackpressured(): boolean {
 }
 
 /**
- * Drains frames from the ring buffer within a time budget.
- * Uses busy-polling to avoid timer coalescing issues with setTimeout.
+ * Drains all available frames from the ring buffer in a single burst.
+ *
+ * Processes every sample the producer has written without imposing a time budget.
+ * This maximizes work done per scheduling slot, which is critical on
+ * background-throttled contexts where Chrome may delay rescheduling by
+ * 100-280ms after each yield point.
+ *
+ * The loop breaks only when:
+ * - The ring buffer is empty (readFromRingBuffer returns 0)
+ * - Backpressure is detected (encoder or WebSocket, mode-dependent)
  *
  * Backpressure handling differs by mode:
  * - Quality mode: only check encoder backpressure (WebSocket handled by frame queue)
@@ -580,11 +576,10 @@ function isEncoderBackpressured(): boolean {
  *
  * @returns Number of complete frames drained
  */
-function drainWithTimeBudget(): number {
+function drainAvailable(): number {
   let framesProcessed = 0;
-  const budgetStart = performance.now();
 
-  while (performance.now() - budgetStart < PROCESS_BUDGET_MS) {
+  while (true) {
     // Check backpressure before processing each frame
     // Quality mode: only block on encoder (WebSocket handled by frame queue)
     // Realtime mode: block on both encoder and WebSocket
@@ -617,9 +612,12 @@ function drainWithTimeBudget(): number {
 /**
  * Main consumption loop with time-based pacing and backpressure-aware flow control.
  *
- * Uses performance.now() for rate control to pace frame production at ~20ms intervals,
- * preventing burst processing and smoothing encoder/network load. Avoids setTimeout
- * timer coalescing issues by busy-polling within a ~4ms time budget per wake cycle.
+ * Uses performance.now() for rate control to pace frame production at codec-native
+ * intervals, preventing burst processing and smoothing encoder/network load.
+ *
+ * Each scheduling slot drains ALL available data from the ring buffer in a single
+ * burst via drainAvailable(), maximizing throughput when Chrome background-throttles
+ * the worker (scheduling gaps of 100-280ms on low-end devices).
  *
  * Flow control varies by streaming policy:
  * - Quality mode: pause encoding on backpressure (no drops), resume with hysteresis
@@ -627,12 +625,13 @@ function drainWithTimeBudget(): number {
  *
  * Common flow:
  * - If ahead of schedule: yield until next frame is due
- * - If data available: drain within time budget, update frame timing, yield thread
+ * - If data available: drain all available frames, update frame timing, yield thread
  * - If buffer empty: wait on write index via Atomics.waitAsync
  *
  * Drift handling:
  * - Allows burst catch-up of ~6 frames when recovering from stalls
- * - Clamps drift to prevent unbounded catch-up after long pauses
+ * - Backward clamp prevents unbounded catch-up after long pauses
+ * - Forward clamp prevents false-ahead pacing after draining a large backlog
  */
 async function consumeLoop(): Promise<void> {
   if (!control) return;
@@ -701,8 +700,8 @@ async function consumeLoop(): Promise<void> {
       }
     }
 
-    // Drain frames within time budget, checking backpressure between frames
-    const framesThisWake = drainWithTimeBudget();
+    // Drain all available frames, checking backpressure between frames
+    const framesThisWake = drainAvailable();
 
     if (framesThisWake > 0) {
       wakeupCount++;
@@ -720,6 +719,15 @@ async function consumeLoop(): Promise<void> {
       if (nextFrameDueTime < nowAfterDrain - maxDriftMs) {
         nextFrameDueTime = nowAfterDrain - maxDriftMs;
       }
+
+      // Clamp: don't let due time jump more than one frame period ahead of wall clock
+      // After draining a large backlog (e.g., 20 frames of 10ms = 200ms of audio time
+      // processed in ~6ms of wall time), nextFrameDueTime would be ~194ms ahead.
+      // Without this clamp, the pacing logic above would yield for that entire duration,
+      // defeating the purpose of burst processing in throttled scheduling contexts.
+      if (nextFrameDueTime > nowAfterDrain + framePeriodMs) {
+        nextFrameDueTime = nowAfterDrain + framePeriodMs;
+      }
     }
 
     maybePostStats(s, control, bufferSize, getCustomMetrics, resetCustomCounters);
@@ -730,8 +738,8 @@ async function consumeLoop(): Promise<void> {
     const available = (write - read) >>> 0;
 
     if (available > 0) {
-      // Data available but we've exhausted our time budget
-      // Just yield the thread (setTimeout(0)), time-based pacing handles the wait
+      // Data still available (backpressure limited the drain)
+      // Just yield the thread briefly, time-based pacing handles the wait
       await yieldMacrotask(0);
       continue;
     }


### PR DESCRIPTION
## What

Removes the 4ms `PROCESS_BUDGET_MS` time cap from the audio consumer worker's drain loop and adds a matching forward clamp on `nextFrameDueTime`. Two related changes in one file (`apps/extension/src/offscreen/audio-consumer.worker.ts`):

- **Drain unbounded:** Rename `drainWithTimeBudget` → `drainAvailable`. Replace the `while (performance.now() - start < 4)` guard with `while (true)`, breaking only when the ring buffer is empty or backpressure is reached.
- **Forward clamp:** After a drain that processes a large backlog (e.g. 20 frames of 10ms audio drained in ~6ms of wall time), `nextFrameDueTime` would sit ~194ms ahead of wall clock. Without a clamp, the pacing logic would yield for that entire duration, defeating the burst-recovery the drain change enables. The new clamp caps the forward jump to one frame period past `performance.now()`.

## Why

On 2-core Chrome targets under thermal throttling, Chrome reschedules the consumer worker with 100–280ms gaps between wakes. Under the old 4ms cap, each wake could only drain ~4 frames regardless of how much the ring buffer had accumulated, compounding into ~12% frame loss on long sessions. Lifting the cap lets the worker catch up fully on each wake; the forward clamp makes sure that catch-up doesn't silently turn into a self-inflicted wait.

This only affects codec paths that still flow through `audio-consumer.worker` — i.e. the FLAC path. PCM has been on MSTP (`audio-relay.worker`) since #96 and does not hit this code. This PR originated as part 1+2 of `b839070` on #82; part 3 (a PcmEncoder buffer-reuse optimization) is deliberately excluded — main intentionally allocates fresh `Int16Array` per encode to avoid WebSocket `send()` async-copy corruption, a choice we're not revisiting here.

## How to Test

- `bun run typecheck` (clean).
- `bun run lint` (no new warnings; the 4 pre-existing JSDoc warnings are unchanged).
- Build the extension and run a FLAC-codec stream for ~5 minutes on a 2-core device (Surface Go or similar). The pipeline instrumentation timeline (from #101) should show cadence-queue underflow count drop substantially compared to main.
- On an unthrottled dev machine, verify no regression on healthy conditions — `drainAvailable()` should still break promptly when backpressure engages.
- Confirm PCM streams are unaffected: the MSTP relay worker does not invoke this drain path.

## Related Issue

Extracts parts 1+2 of `b839070` from #82. Part 3 (PcmEncoder pre-alloc) omitted as noted above.

---

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)