### PR TITLE
feat(protocol): exchange version metadata, warn on out-of-date companions

### DIFF
--- a/.changeset/handshake-version-metadata.md
+++ b/.changeset/handshake-version-metadata.md
@@ -1,0 +1,18 @@
+---
+'@thaumic-cast/protocol': minor
+'@thaumic-cast/shared': minor
+'@thaumic-cast/core': minor
+'@thaumic-cast/extension': minor
+'@thaumic-cast/desktop': minor
+'@thaumic-cast/server': minor
+---
+
+Exchange version metadata in the WebSocket handshake so the extension can warn users when their desktop app or server is out of date.
+
+- `WsHandshakeAckPayload` now carries optional `protocolVersion`, `appVersion`, and `appType` fields populated by the companion (desktop or headless server).
+- `thaumic-core` exposes a new `AppInfo` / `AppType` pair passed to `AppState::new`, and populates the three new fields every time it sends a handshake ACK. Both `apps/desktop` and `apps/server` thread their own `env!("CARGO_PKG_VERSION")` through.
+- The extension compares the reported `protocolVersion` against `MIN_COMPATIBLE_PROTOCOL_VERSION` on connect and surfaces a dismissible warning Alert in the popup when the companion is out of date. The Alert's action button deep-links to the GitHub releases page; dismissal is persisted per companion `appVersion` in `chrome.storage.local`, so upgrading (or downgrading to a new version) re-arms the warning.
+- Extension options now show the connected companion's version info in the About section; the desktop Settings page gains a matching About section.
+- Older companions predating this change omit the new fields; the extension treats absence as "unknown, assume compatible" rather than erroring, so users on old builds are not disrupted. Unknown `appType` values (e.g. a future `"cli"`) degrade to `undefined` via `.catch()` on the schema, so a newer companion can't break an older extension either.
+
+No new remote calls are introduced — the check runs entirely off the local handshake, preserving the privacy promise in PRIVACY.md.

--- a/.changeset/handshake-version-metadata.md
+++ b/.changeset/handshake-version-metadata.md
@@ -5,14 +5,20 @@
 '@thaumic-cast/extension': minor
 '@thaumic-cast/desktop': minor
 '@thaumic-cast/server': minor
+'@thaumic-cast/ui': patch
 ---
 
-Exchange version metadata in the WebSocket handshake so the extension can warn users when their desktop app or server is out of date.
+Exchange companion version metadata over the existing connection so the extension can warn users when their desktop app or server is out of date.
 
-- `WsHandshakeAckPayload` now carries optional `protocolVersion`, `appVersion`, and `appType` fields populated by the companion (desktop or headless server).
-- `thaumic-core` exposes a new `AppInfo` / `AppType` pair passed to `AppState::new`, and populates the three new fields every time it sends a handshake ACK. Both `apps/desktop` and `apps/server` thread their own `env!("CARGO_PKG_VERSION")` through.
-- The extension compares the reported `protocolVersion` against `MIN_COMPATIBLE_PROTOCOL_VERSION` on connect and surfaces a dismissible warning Alert in the popup when the companion is out of date. The Alert's action button deep-links to the GitHub releases page; dismissal is persisted per companion `appVersion` in `chrome.storage.local`, so upgrading (or downgrading to a new version) re-arms the warning.
-- Extension options now show the connected companion's version info in the About section; the desktop Settings page gains a matching About section.
-- Older companions predating this change omit the new fields; the extension treats absence as "unknown, assume compatible" rather than erroring, so users on old builds are not disrupted. Unknown `appType` values (e.g. a future `"cli"`) degrade to `undefined` via `.catch()` on the schema, so a newer companion can't break an older extension either.
+- `/health` now reports `appType` alongside the existing service identifier and stream limit. The extension reads it at discovery time so it knows which companion it's talking to before the WebSocket even connects.
+- The WebSocket `INITIAL_STATE` payload — sent on every connect, including the always-on control connection — now carries `appType`, `appVersion`, and `protocolVersion`. The extension persists these into the existing `connectionState` store; there is no separate companion-info storage.
+- `thaumic-core` exposes a new `AppInfo` / `AppType` pair passed to `AppState::new`. `apps/desktop` and `apps/server` each thread their own `env!("CARGO_PKG_VERSION")` through.
+- The extension compares the reported `protocolVersion` against `MIN_COMPATIBLE_PROTOCOL_VERSION` on every connect:
+  - Renders a dismissible warning Alert in the popup with an "Update Desktop App" / "Update Server" / "Update" action button (chosen from `appType`) deep-linking to the GitHub releases page.
+  - Renders a persistent inline "Update available" link in the popup footer and in the options About section, even after the Alert has been dismissed, so the user always has a path to the releases page.
+  - Dismissal is keyed by `appVersion` (or `null` for pre-0.4.0 companions) in `chrome.storage.local`, so rolling forward — including from "unknown" to a real version — re-arms the warning.
+- The popup footer copy is type-aware: "Connected to Desktop App", "Connected to Server", or just "Connected" when the type is unknown.
+- Older companions that omit the new fields are treated as out-of-date (not "assume compatible"), since the extension may have been auto-updated by Chrome ahead of the user updating the companion. The Alert and footer link still appear; copy degrades gracefully ("Your app predates this extension and can't report its version").
+- Shared UI: new `link` variant on `<Button>` for inline text-link CTAs.
 
-No new remote calls are introduced — the check runs entirely off the local handshake, preserving the privacy promise in PRIVACY.md.
+No new remote calls are introduced — the check runs entirely off discovery and the existing WebSocket, preserving the privacy promise in PRIVACY.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,69 @@ bun changeset
 
 Follow the prompts to select the package and bump type (major/minor/patch).
 
+### Protocol versioning
+
+The wire format between the extension and the companion (`apps/desktop`,
+`apps/server`) is versioned independently via `@thaumic-cast/protocol`. The
+extension auto-updates through the Chrome Web Store but the companion does not,
+so version drift is common — the extension relies on the `protocolVersion`
+field returned in the WebSocket handshake ACK to detect incompatible companions
+and nudge users to update.
+
+Three places hold the wire version; all three must agree:
+
+- `packages/protocol/package.json` — the package's npm-style semver. This is
+  the source of truth; the other two are kept in sync from here.
+- `packages/protocol/src/websocket.ts` — the exported `PROTOCOL_VERSION`
+  constant the extension embeds.
+- `packages/thaumic-core/src/protocol_constants.rs` — the Rust `PROTOCOL_VERSION`
+  the companion emits in the handshake ACK.
+
+`bun run sync-versions` (invoked automatically by `bun run changeset:version`
+during a release) propagates the `package.json` version into the two
+`PROTOCOL_VERSION` constants. You never edit those two constants by hand; diffs
+against them only appear in release PRs, not feature PRs. If `sync-versions`
+can't locate either constant (e.g. the declaration syntax changed), it exits
+non-zero and fails the release loudly rather than shipping stale values.
+
+`MIN_COMPATIBLE_PROTOCOL_VERSION` in `packages/shared/src/constants.ts` is
+different: it _is_ a hand-edited feature-PR concern, since bumping it is a
+product decision, not a mechanical sync. See step 2 below.
+
+Note: `@thaumic-cast/desktop`, `@thaumic-cast/extension`, and
+`@thaumic-cast/server` are in a `fixed` group (see `.changeset/config.json`),
+so bumping any one of them automatically bumps the others to match. The
+`protocol`, `core`, and `shared` packages are independent and should be
+listed explicitly in the changeset when they change.
+
+When you change the wire format:
+
+1. Run `bun run changeset` to record the change (this creates a changeset file
+   but does _not_ yet modify any `package.json`). Bump `@thaumic-cast/protocol`:
+   - **Minor** for additive, backwards-compatible changes (a new optional
+     field, a new message type older clients can ignore).
+   - **Major** for breaking changes (removing or renaming a field, changing
+     semantics, tightening a previously-permissive field).
+     The release pipeline (`bun run changeset:version`, run at release time,
+     not on the feature branch) applies the bump to `package.json` and then
+     invokes `sync-versions` to propagate the two `PROTOCOL_VERSION` constants.
+2. Decide whether to raise `MIN_COMPATIBLE_PROTOCOL_VERSION` in
+   `packages/shared/src/constants.ts`. Unlike `PROTOCOL_VERSION`, this is
+   edited by hand in the feature PR. `MIN_COMPATIBLE_PROTOCOL_VERSION` is a
+   watermark: once set to `X.Y.Z`, the extension surfaces the out-of-date
+   warning Alert for any companion reporting a `protocolVersion` below
+   `X.Y.Z`. Companions that omit the field entirely (pre-0.4.0 builds) are
+   treated as "unknown, assume compatible" and never warned.
+   - **Always** bump MIN on a major wire change — older companions will
+     actually break playback, so we want to prompt aggressively.
+   - **Optionally** bump MIN on a minor change if you want users to
+     proactively pick up the improvement (e.g. the new field fixes a UX bug
+     that only older extensions paper over).
+   - **Skip** a MIN bump for patch-level changes or when older companions
+     keep working fine.
+3. Describe the change in the changeset body. Include enough detail for a user
+   to understand why they're seeing the update prompt.
+
 ## Code Style
 
 - **Linting:** ESLint + Prettier + Stylelint run automatically on commit.

--- a/apps/desktop/src-tauri/src/api/mod.rs
+++ b/apps/desktop/src-tauri/src/api/mod.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 use tauri::{AppHandle, Manager};
 use thaumic_core::{
-    bootstrap_services, AppState as CoreAppState, ArtworkConfig, ArtworkSource,
+    bootstrap_services, AppInfo, AppState as CoreAppState, AppType, ArtworkConfig, ArtworkSource,
     BootstrappedServices, Config,
 };
 #[cfg(windows)]
@@ -265,6 +265,7 @@ impl AppState {
             &self.services,
             Arc::clone(&self.config),
             self.artwork_config(),
+            AppInfo::new(env!("CARGO_PKG_VERSION"), AppType::Desktop),
         );
 
         #[cfg(windows)]

--- a/apps/desktop/src/components/onboarding/ExtensionStep.tsx
+++ b/apps/desktop/src/components/onboarding/ExtensionStep.tsx
@@ -3,12 +3,12 @@ import { open } from '@tauri-apps/plugin-shell';
 import { WizardStep, Alert, Button } from '@thaumic-cast/ui';
 import { Puzzle, ExternalLink, Download } from 'lucide-preact';
 import { useTranslation } from 'react-i18next';
+import { GITHUB_RELEASES_URL } from '@thaumic-cast/shared';
 import { stats, fetchStats } from '../../state/store';
 import styles from './ExtensionStep.module.css';
 
 const CHROME_STORE_URL =
   'https://chromewebstore.google.com/detail/hpemmkbecklfacogdidaoncjmfadgedm';
-const GITHUB_RELEASES_URL = 'https://github.com/brew-lab/thaumic-cast/releases/latest';
 
 /**
  * Extension installation guide step.

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -57,6 +57,12 @@
   "settings.manual_speakers_empty": "No speakers have been added by hand",
   "settings.add_speaker": "Add by IP address",
   "settings.remove_speaker": "Banish",
+  "settings.about": "About",
+  "settings.about_app": "Thaumic Cast Desktop",
+  "settings.about_version": "Version {{version}}",
+  "settings.about_protocol": "Protocol v{{version}}",
+  "settings.check_for_updates": "Check for updates",
+  "settings.check_for_updates_description": "Opens the releases page in your browser",
 
   "error.page_not_found": "This Page Has Wandered Off",
   "error.go_home": "Return Home",

--- a/apps/desktop/src/views/Settings.tsx
+++ b/apps/desktop/src/views/Settings.tsx
@@ -6,9 +6,12 @@ import {
   removeManualSpeakerIp,
 } from '../state/store';
 import { useTranslation } from 'react-i18next';
-import { X } from 'lucide-preact';
-import { Card } from '@thaumic-cast/ui';
-import { createLogger } from '@thaumic-cast/shared';
+import { ExternalLink, X } from 'lucide-preact';
+import { getVersion } from '@tauri-apps/api/app';
+import { open } from '@tauri-apps/plugin-shell';
+import { Button, Card } from '@thaumic-cast/ui';
+import { PROTOCOL_VERSION } from '@thaumic-cast/protocol';
+import { createLogger, GITHUB_RELEASES_URL } from '@thaumic-cast/shared';
 import i18n, { resources, SupportedLocale } from '../lib/i18n';
 import { type ThemeMode, getTheme, saveTheme, applyTheme } from '../lib/theme';
 import { ManualSpeakerForm } from '../components/ManualSpeakerForm';
@@ -42,6 +45,9 @@ export function Settings() {
   const [manualIps, setManualIps] = useState<string[]>([]);
   const [removingIp, setRemovingIp] = useState<string | null>(null);
 
+  // App version for the About section
+  const [appVersion, setAppVersion] = useState<string>('');
+
   const handleSpeakerAdded = useCallback((ip: string) => {
     // Prevent duplicates in UI (backend also prevents, but avoid UI flicker)
     setManualIps((prev) => (prev.includes(ip) ? prev : [...prev, ip]));
@@ -55,6 +61,14 @@ export function Settings() {
     getManualSpeakerIps()
       .then(setManualIps)
       .catch(() => setManualIps([]));
+
+    getVersion()
+      .then(setAppVersion)
+      .catch(() => setAppVersion(''));
+  }, []);
+
+  const handleCheckForUpdates = useCallback(() => {
+    open(GITHUB_RELEASES_URL);
   }, []);
 
   const handleRemoveSpeaker = useCallback(async (ip: string) => {
@@ -200,6 +214,29 @@ export function Settings() {
               buttonVariant="secondary"
               onSuccess={handleSpeakerAdded}
             />
+          </div>
+        </div>
+      </Card>
+
+      {/* About Section */}
+      <Card id="about" title={t('settings.about')} titleLevel="h3" className={styles.section}>
+        <div className={styles.sectionContent}>
+          <div className={styles.field}>
+            <label className={styles.fieldLabel}>{t('settings.about_app')}</label>
+            <span className={styles.hint}>
+              {appVersion ? t('settings.about_version', { version: appVersion }) : '—'}
+            </span>
+            <span className={styles.hint}>
+              {t('settings.about_protocol', { version: PROTOCOL_VERSION })}
+            </span>
+          </div>
+
+          <div className={styles.field}>
+            <Button variant="secondary" onClick={handleCheckForUpdates}>
+              <ExternalLink size={14} />
+              {t('settings.check_for_updates')}
+            </Button>
+            <span className={styles.hint}>{t('settings.check_for_updates_description')}</span>
           </div>
         </div>
       </Card>

--- a/apps/desktop/src/views/Settings.tsx
+++ b/apps/desktop/src/views/Settings.tsx
@@ -222,21 +222,21 @@ export function Settings() {
       <Card id="about" title={t('settings.about')} titleLevel="h3" className={styles.section}>
         <div className={styles.sectionContent}>
           <div className={styles.field}>
-            <label className={styles.fieldLabel}>{t('settings.about_app')}</label>
-            <span className={styles.hint}>
+            <div className={styles.fieldLabel}>{t('settings.about_app')}</div>
+            <div className={styles.hint}>
               {appVersion ? t('settings.about_version', { version: appVersion }) : '—'}
-            </span>
-            <span className={styles.hint}>
+            </div>
+            <div className={styles.hint}>
               {t('settings.about_protocol', { version: PROTOCOL_VERSION })}
-            </span>
+            </div>
           </div>
 
           <div className={styles.field}>
             <Button variant="secondary" onClick={handleCheckForUpdates}>
-              <ExternalLink size={14} />
+              <ExternalLink size={16} />
               {t('settings.check_for_updates')}
             </Button>
-            <span className={styles.hint}>{t('settings.check_for_updates_description')}</span>
+            <div className={styles.hint}>{t('settings.check_for_updates_description')}</div>
           </div>
         </div>
       </Card>

--- a/apps/extension/src/background/connection-state.ts
+++ b/apps/extension/src/background/connection-state.ts
@@ -13,6 +13,7 @@
  * - Message passing
  */
 
+import { type AppType } from '@thaumic-cast/protocol';
 import { createLogger } from '@thaumic-cast/shared';
 import { persistenceManager } from './persistence-manager';
 
@@ -23,6 +24,13 @@ export type NetworkHealthStatus = 'ok' | 'degraded';
 
 /**
  * Connection state snapshot.
+ *
+ * Includes companion version metadata (`appType`, `appVersion`,
+ * `protocolVersion`) so the popup and About surface can describe the
+ * connection without a separate storage key. `appType` is populated at
+ * discovery time from `/health`; `appVersion`/`protocolVersion` arrive on
+ * the WebSocket via `INITIAL_STATE`. All three are nullable: pre-0.4.0
+ * companions don't advertise them.
  */
 export interface ConnectionState {
   /** Whether WebSocket is currently connected */
@@ -39,6 +47,12 @@ export interface ConnectionState {
   networkHealth: NetworkHealthStatus;
   /** Reason for degraded network health (null if healthy) */
   networkHealthReason: string | null;
+  /** Which companion is connected (desktop/server). Null on pre-0.4.0 builds. */
+  appType: AppType | null;
+  /** Companion app semver. Null on pre-0.4.0 builds. */
+  appVersion: string | null;
+  /** Wire-protocol semver advertised by the companion. Null on pre-0.4.0 builds. */
+  protocolVersion: string | null;
 }
 
 /** Current connection state */
@@ -50,6 +64,9 @@ let state: ConnectionState = {
   lastError: null,
   networkHealth: 'ok',
   networkHealthReason: null,
+  appType: null,
+  appVersion: null,
+  protocolVersion: null,
 };
 
 /**
@@ -74,6 +91,9 @@ const storage = persistenceManager.register<ConnectionState>(
         lastError: s.lastError ?? null,
         networkHealth: s.networkHealth ?? 'ok',
         networkHealthReason: s.networkHealthReason ?? null,
+        appType: s.appType ?? null,
+        appVersion: s.appVersion ?? null,
+        protocolVersion: s.protocolVersion ?? null,
       };
     },
   },
@@ -113,16 +133,50 @@ export function setConnected(connected: boolean): void {
 
 /**
  * Sets the discovered desktop app info.
+ *
+ * `appType` is supplied when `/health` reports it (≥0.4.0 companions). Older
+ * companions return undefined here; the extension treats that as "unknown"
+ * until `INITIAL_STATE` arrives (it'll likely be unknown there too for
+ * pre-0.4.0 builds).
+ *
  * @param url - The desktop app base URL
  * @param maxStreams - Maximum concurrent streams allowed
+ * @param appType - Companion type from `/health`, or undefined if not reported
  */
-export function setDesktopApp(url: string, maxStreams: number): void {
+export function setDesktopApp(url: string, maxStreams: number, appType?: AppType): void {
   state = {
     ...state,
     desktopAppUrl: url,
     maxStreams,
     lastDiscoveredAt: Date.now(),
     lastError: null,
+    appType: appType ?? state.appType,
+  };
+  storage.schedule();
+}
+
+/**
+ * Records companion version metadata captured from `INITIAL_STATE`.
+ *
+ * Called whenever the WebSocket (re)connects. `appType` is allowed to be
+ * `undefined`/`null` here; we keep any value previously set by `/health` in
+ * that case so we don't regress to "unknown" on a transient disconnect.
+ *
+ * @param metadata - Version fields reported by the companion
+ * @param metadata.appType - Companion type (`desktop` | `server`), or null/undefined when absent
+ * @param metadata.appVersion - Companion app semver, or null when absent (pre-0.4.0)
+ * @param metadata.protocolVersion - Wire-protocol semver, or null when absent (pre-0.4.0)
+ */
+export function setConnectionMetadata(metadata: {
+  appType: AppType | null | undefined;
+  appVersion: string | null;
+  protocolVersion: string | null;
+}): void {
+  state = {
+    ...state,
+    appType: metadata.appType ?? state.appType,
+    appVersion: metadata.appVersion,
+    protocolVersion: metadata.protocolVersion,
   };
   storage.schedule();
 }
@@ -167,6 +221,9 @@ export function clearConnectionState(): void {
     lastError: 'error_desktop_not_found',
     networkHealth: 'ok',
     networkHealthReason: null,
+    appType: null,
+    appVersion: null,
+    protocolVersion: null,
   };
   storage.schedule();
 }

--- a/apps/extension/src/background/discovery.ts
+++ b/apps/extension/src/background/discovery.ts
@@ -14,7 +14,7 @@
  * - WebSocket lifecycle (handled by offscreen-manager.ts)
  */
 
-import { DEFAULT_MAX_CONCURRENT_STREAMS } from '@thaumic-cast/protocol';
+import { DEFAULT_MAX_CONCURRENT_STREAMS, type AppType } from '@thaumic-cast/protocol';
 import { createLogger } from '@thaumic-cast/shared';
 import { loadExtensionSettings } from '../lib/settings';
 import { getConnectionState, setDesktopApp } from './connection-state';
@@ -34,6 +34,11 @@ export interface DiscoveredApp {
   url: string;
   /** Maximum concurrent streams allowed by the server. */
   maxStreams: number;
+  /**
+   * Which companion the extension is talking to. Absent when the companion
+   * predates `/health` reporting `appType` (pre-0.4.0).
+   */
+  appType?: AppType;
 }
 
 /**
@@ -56,9 +61,12 @@ async function probeUrl(url: string): Promise<DiscoveredApp | null> {
       const data = await response.json();
 
       if (data.service === 'thaumic-cast') {
+        const appType: AppType | undefined =
+          data.appType === 'desktop' || data.appType === 'server' ? data.appType : undefined;
         return {
           url,
           maxStreams: data.limits?.maxStreams || DEFAULT_MAX_CONCURRENT_STREAMS,
+          appType,
         };
       }
     }
@@ -92,7 +100,7 @@ export async function discoverDesktopApp(force = false): Promise<DiscoveredApp |
     const app = await probeUrl(settings.serverUrl);
 
     if (app) {
-      setDesktopApp(app.url, app.maxStreams);
+      setDesktopApp(app.url, app.maxStreams, app.appType);
       return app;
     }
 
@@ -115,6 +123,7 @@ export async function discoverDesktopApp(force = false): Promise<DiscoveredApp |
           return {
             url: connState.desktopAppUrl,
             maxStreams: connState.maxStreams ?? DEFAULT_MAX_CONCURRENT_STREAMS,
+            appType: connState.appType ?? undefined,
           };
         }
       } catch {
@@ -135,7 +144,7 @@ export async function discoverDesktopApp(force = false): Promise<DiscoveredApp |
 
   if (foundApp) {
     log.info(`Desktop App discovered at: ${foundApp.url} (Limit: ${foundApp.maxStreams})`);
-    setDesktopApp(foundApp.url, foundApp.maxStreams);
+    setDesktopApp(foundApp.url, foundApp.maxStreams, foundApp.appType);
     return foundApp;
   }
 

--- a/apps/extension/src/background/handlers/connection.ts
+++ b/apps/extension/src/background/handlers/connection.ts
@@ -15,7 +15,7 @@
  */
 
 import { createLogger } from '@thaumic-cast/shared';
-import type { SonosStateSnapshot } from '@thaumic-cast/protocol';
+import type { AppType, SonosStateSnapshot } from '@thaumic-cast/protocol';
 import type {
   EnsureConnectionResponse,
   NetworkEventMessage,
@@ -26,6 +26,7 @@ import {
   getConnectionState,
   setConnected,
   setConnectionError,
+  setConnectionMetadata,
   clearConnectionState,
   setNetworkHealth,
   setDesktopApp,
@@ -90,10 +91,23 @@ export async function discoverAndCache(force = false): Promise<DiscoverResult | 
 
 /**
  * Handles WebSocket connected event from offscreen.
+ *
  * @param state - The initial Sonos state from desktop (may include network health)
+ * @param metadata - Companion version metadata from `INITIAL_STATE`
+ * @param metadata.appType - Companion type (`desktop` | `server`), or null when absent
+ * @param metadata.appVersion - Companion app semver, or null when absent (pre-0.4.0)
+ * @param metadata.protocolVersion - Wire-protocol semver, or null when absent (pre-0.4.0)
  */
-export function handleWsConnected(state: SonosStateSnapshot): void {
+export function handleWsConnected(
+  state: SonosStateSnapshot,
+  metadata: {
+    appType: AppType | null;
+    appVersion: string | null;
+    protocolVersion: string | null;
+  },
+): void {
   setConnected(true);
+  setConnectionMetadata(metadata);
   updateSonosState(state);
   log.info('WebSocket connected');
 

--- a/apps/extension/src/background/routes/offscreen-routes.ts
+++ b/apps/extension/src/background/routes/offscreen-routes.ts
@@ -39,7 +39,11 @@ const log = createLogger('OffscreenRoutes');
  */
 export function registerOffscreenRoutes(): void {
   registerValidatedRoute('WS_CONNECTED', WsConnectedMessageSchema, (msg) => {
-    handleWsConnected(msg.state);
+    handleWsConnected(msg.state, {
+      appType: msg.appType ?? null,
+      appVersion: msg.appVersion,
+      protocolVersion: msg.protocolVersion,
+    });
     return { success: true };
   });
 

--- a/apps/extension/src/lib/message-schemas.ts
+++ b/apps/extension/src/lib/message-schemas.ts
@@ -299,9 +299,23 @@ export type SyncSonosStateMessage = z.infer<typeof SyncSonosStateMessageSchema>;
 // WebSocket Status Messages (offscreen → background)
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Sent by the offscreen control connection on every WebSocket connect (after
+ * `INITIAL_STATE` arrives). Carries Sonos state plus the companion's reported
+ * version metadata so the background can update everything atomically — no
+ * second message, no ordering races.
+ *
+ * `appType`/`appVersion`/`protocolVersion` are nullable: pre-0.4.0 companions
+ * advertise none of them, but we still want to record "connected to a
+ * companion that doesn't report its version" so the popup can drive the
+ * out-of-date warning.
+ */
 export const WsConnectedMessageSchema = z.object({
   type: z.literal('WS_CONNECTED'),
   state: SonosStateSnapshotSchema,
+  appType: z.enum(['desktop', 'server']).nullable().optional(),
+  appVersion: z.string().nullable(),
+  protocolVersion: z.string().nullable(),
 });
 export type WsConnectedMessage = z.infer<typeof WsConnectedMessageSchema>;
 

--- a/apps/extension/src/lib/versionCheck.ts
+++ b/apps/extension/src/lib/versionCheck.ts
@@ -150,3 +150,31 @@ export async function setDismissedCompanionVersion(appVersion: string): Promise<
     [DISMISSED_COMPANION_VERSION_STORAGE_KEY]: { appVersion } satisfies DismissedCompanionVersion,
   });
 }
+
+/**
+ * Resolves the i18n key identifying the companion type label
+ * (`about_companion_type_{desktop,server,generic}`). Unknown or absent
+ * `appType` falls through to the generic label so copy still reads naturally
+ * when a newer companion sends an `appType` this extension doesn't recognise.
+ *
+ * @param appType - Reported by the companion, or `undefined` when absent/unknown
+ * @returns i18n key for the companion type display label
+ */
+export function companionTypeLabelKey(appType: AppType | undefined): string {
+  if (appType === 'server') return 'about_companion_type_server';
+  if (appType === 'desktop') return 'about_companion_type_desktop';
+  return 'about_companion_type_generic';
+}
+
+/**
+ * Resolves the i18n key for the Alert action button that prompts the user to
+ * update the companion (`version_mismatch_action_{desktop,server,generic}`).
+ *
+ * @param appType - Reported by the companion, or `undefined` when absent/unknown
+ * @returns i18n key for the action button label
+ */
+export function versionMismatchActionKey(appType: AppType | undefined): string {
+  if (appType === 'server') return 'version_mismatch_action_server';
+  if (appType === 'desktop') return 'version_mismatch_action_desktop';
+  return 'version_mismatch_action_generic';
+}

--- a/apps/extension/src/lib/versionCheck.ts
+++ b/apps/extension/src/lib/versionCheck.ts
@@ -1,0 +1,152 @@
+/**
+ * Companion version tracking.
+ *
+ * On every successful WebSocket handshake the offscreen worker persists the
+ * companion's reported metadata (`appVersion`, `protocolVersion`, `appType`) to
+ * `chrome.storage.local`. The popup reads from the same storage to:
+ *   1. Display the connected companion in its About surface.
+ *   2. Warn the user when `protocolVersion` is below
+ *      `MIN_COMPATIBLE_PROTOCOL_VERSION` and route them to the GitHub releases
+ *      page so they can update the desktop app or server.
+ *
+ * The warning dismissal is keyed on the companion's `appVersion`: once the user
+ * dismisses for v0.11.0, the warning stays silent — but if they roll forward
+ * (or back) to a different build the dismissal no longer matches and the Alert
+ * re-appears, so stale dismissals don't mask real mismatches.
+ */
+
+import type { AppType } from '@thaumic-cast/protocol';
+import { MIN_COMPATIBLE_PROTOCOL_VERSION } from '@thaumic-cast/shared';
+
+/** Key for the currently-connected companion's version metadata. */
+export const COMPANION_INFO_STORAGE_KEY = 'companionInfo';
+
+/** Key for the companion `appVersion` the user last dismissed a warning for. */
+export const DISMISSED_COMPANION_VERSION_STORAGE_KEY = 'dismissedCompanionVersion';
+
+/**
+ * Companion metadata captured from the handshake ACK.
+ *
+ * `appVersion` and `protocolVersion` are required: without them we cannot show
+ * meaningful About content or drive the out-of-date warning, and persisting
+ * partial data would only pollute the UI. `appType`, by contrast, is allowed
+ * to be undefined — a future companion may introduce a new variant (e.g.
+ * `"cli"`) that older extensions don't recognise, and `WsHandshakeAckPayloadSchema`
+ * degrades unknown values to `undefined`. We want the About surface and the
+ * warning to keep working in that case, just with a generic "companion" label.
+ *
+ * Pre-0.4.0 companions omit all three fields and are treated as "unknown,
+ * assume compatible" — nothing is persisted for them.
+ */
+export interface CompanionInfo {
+  appVersion: string;
+  protocolVersion: string;
+  appType?: AppType;
+}
+
+/** Persisted "user has already dismissed the warning for this companion build" marker. */
+export interface DismissedCompanionVersion {
+  appVersion: string;
+}
+
+/**
+ * Compares two semver-style "X.Y.Z" strings.
+ *
+ * Any prerelease suffix (e.g. `-beta.1`) is stripped before comparison —
+ * the repo ships stable `0.x.y` tags so this is sufficient and avoids pulling
+ * in a full semver dependency. Missing or malformed segments are treated as
+ * `0`, so `"1"` compares less than `"1.0.1"`.
+ *
+ * @param a - First version string
+ * @param b - Second version string
+ * @returns Negative if `a < b`, zero if equal, positive if `a > b`
+ */
+export function compareSemver(a: string, b: string): number {
+  const parts = (v: string): [number, number, number] => {
+    const core = v.split('-', 1)[0] ?? '';
+    const [maj = '0', min = '0', pat = '0'] = core.split('.');
+    return [Number(maj) || 0, Number(min) || 0, Number(pat) || 0];
+  };
+  const [aMaj, aMin, aPat] = parts(a);
+  const [bMaj, bMin, bPat] = parts(b);
+  if (aMaj !== bMaj) return aMaj - bMaj;
+  if (aMin !== bMin) return aMin - bMin;
+  return aPat - bPat;
+}
+
+/**
+ * Whether `actual` is at least `min`. Used to gate the out-of-date warning.
+ *
+ * @param actual - Version reported by the companion
+ * @param min - Minimum version the extension requires
+ * @returns `true` if `actual >= min`
+ */
+export function isCompatible(actual: string, min: string): boolean {
+  return compareSemver(actual, min) >= 0;
+}
+
+/**
+ * True when the extension should surface the "update your companion" warning
+ * — i.e. the companion reported a `protocolVersion` below
+ * `MIN_COMPATIBLE_PROTOCOL_VERSION` and the user has not dismissed the warning
+ * for the companion's current `appVersion`.
+ *
+ * Companions that omit `protocolVersion` (pre-0.4.0 builds) are treated as
+ * compatible — we don't want to spam users on older companions who haven't
+ * yet had a chance to update through the normal channel.
+ *
+ * @param companion - Most recent companion info, or null if none yet seen
+ * @param dismissed - Last dismissal record persisted in chrome.storage
+ * @param minProtocolVersion - Override for the minimum compatible protocol version
+ * @returns `true` when the popup should render the out-of-date warning Alert
+ */
+export function shouldWarnAboutVersion(
+  companion: CompanionInfo | null,
+  dismissed: DismissedCompanionVersion | null,
+  minProtocolVersion: string = MIN_COMPATIBLE_PROTOCOL_VERSION,
+): boolean {
+  if (!companion?.protocolVersion) return false;
+  if (isCompatible(companion.protocolVersion, minProtocolVersion)) return false;
+  return dismissed?.appVersion !== companion.appVersion;
+}
+
+/**
+ * Persists the companion info captured during handshake.
+ * @param info - Companion metadata to persist
+ */
+export async function setCompanionInfo(info: CompanionInfo): Promise<void> {
+  await chrome.storage.local.set({ [COMPANION_INFO_STORAGE_KEY]: info });
+}
+
+/**
+ * Reads the most recently captured companion info, if any.
+ * @returns The persisted companion info, or null if the extension hasn't
+ *   completed a handshake since install.
+ */
+export async function getCompanionInfo(): Promise<CompanionInfo | null> {
+  const result = await chrome.storage.local.get(COMPANION_INFO_STORAGE_KEY);
+  const value = result[COMPANION_INFO_STORAGE_KEY] as CompanionInfo | undefined;
+  return value ?? null;
+}
+
+/**
+ * Reads the companion app version for which the user last dismissed the warning.
+ * @returns The dismissed version record, or null if the warning has never been dismissed.
+ */
+export async function getDismissedCompanionVersion(): Promise<DismissedCompanionVersion | null> {
+  const result = await chrome.storage.local.get(DISMISSED_COMPANION_VERSION_STORAGE_KEY);
+  const value = result[DISMISSED_COMPANION_VERSION_STORAGE_KEY] as
+    | DismissedCompanionVersion
+    | undefined;
+  return value ?? null;
+}
+
+/**
+ * Records that the user has dismissed the warning for this companion build.
+ * @param appVersion - The companion's current `appVersion` at the moment of dismissal.
+ */
+export async function setDismissedCompanionVersion(appVersion: string): Promise<void> {
+  await chrome.storage.local.set({
+    [DISMISSED_COMPANION_VERSION_STORAGE_KEY]: { appVersion } satisfies DismissedCompanionVersion,
+  });
+}

--- a/apps/extension/src/lib/versionCheck.ts
+++ b/apps/extension/src/lib/versionCheck.ts
@@ -1,52 +1,61 @@
 /**
  * Companion version tracking.
  *
- * On every successful WebSocket handshake the offscreen worker persists the
- * companion's reported metadata (`appVersion`, `protocolVersion`, `appType`) to
- * `chrome.storage.local`. The popup reads from the same storage to:
- *   1. Display the connected companion in its About surface.
- *   2. Warn the user when `protocolVersion` is below
- *      `MIN_COMPATIBLE_PROTOCOL_VERSION` and route them to the GitHub releases
- *      page so they can update the desktop app or server.
+ * The companion's metadata (`appType`, `appVersion`, `protocolVersion`) is
+ * carried by `connectionState` (see `background/connection-state.ts`):
+ * `appType` lands at discovery time from `/health`, `appVersion` and
+ * `protocolVersion` arrive on the WebSocket via `INITIAL_STATE`. The popup
+ * and options page read them through `useConnectionStatus`. This module
+ * provides the pure helpers that interpret those fields:
+ *   1. Compare against `MIN_COMPATIBLE_PROTOCOL_VERSION` to drive the
+ *      out-of-date warning.
+ *   2. Resolve i18n keys for companion-type labels and update-prompt copy.
  *
- * The warning dismissal is keyed on the companion's `appVersion`: once the user
- * dismisses for v0.11.0, the warning stays silent — but if they roll forward
- * (or back) to a different build the dismissal no longer matches and the Alert
- * re-appears, so stale dismissals don't mask real mismatches.
+ * Pre-0.4.0 companions advertise none of the version fields. We still want
+ * to alert the user — Chrome may auto-update the extension before they
+ * update the companion — so we treat the absence of a `protocolVersion` as
+ * a mismatch.
+ *
+ * The Alert is dismissible per `appVersion` (`null` is its own bucket): once
+ * dismissed it stays silent for that build, but if the companion rolls
+ * forward — including from "unknown" to a real version — the dismissal no
+ * longer matches and the Alert re-appears. Even when dismissed, the popup
+ * footer keeps a persistent "Update available" link so the user always has
+ * a way back to the releases page.
+ *
+ * The dismissal record stays in `chrome.storage.local` (a user preference
+ * that should survive browser restarts), separate from `connectionState`
+ * (ephemeral, in `chrome.storage.session`).
  */
 
 import type { AppType } from '@thaumic-cast/protocol';
 import { MIN_COMPATIBLE_PROTOCOL_VERSION } from '@thaumic-cast/shared';
 
-/** Key for the currently-connected companion's version metadata. */
-export const COMPANION_INFO_STORAGE_KEY = 'companionInfo';
-
 /** Key for the companion `appVersion` the user last dismissed a warning for. */
 export const DISMISSED_COMPANION_VERSION_STORAGE_KEY = 'dismissedCompanionVersion';
 
 /**
- * Companion metadata captured from the handshake ACK.
+ * Companion metadata as consumed by the version-check helpers below.
  *
- * `appVersion` and `protocolVersion` are required: without them we cannot show
- * meaningful About content or drive the out-of-date warning, and persisting
- * partial data would only pollute the UI. `appType`, by contrast, is allowed
- * to be undefined — a future companion may introduce a new variant (e.g.
- * `"cli"`) that older extensions don't recognise, and `WsHandshakeAckPayloadSchema`
- * degrades unknown values to `undefined`. We want the About surface and the
- * warning to keep working in that case, just with a generic "companion" label.
- *
- * Pre-0.4.0 companions omit all three fields and are treated as "unknown,
- * assume compatible" — nothing is persisted for them.
+ * Sourced from `connectionState` — `appType` is populated at discovery time
+ * from `/health`; `appVersion`/`protocolVersion` arrive via the WebSocket
+ * `INITIAL_STATE`. All three are nullable so we can record "connected to a
+ * companion that doesn't advertise its version" (pre-0.4.0).
  */
 export interface CompanionInfo {
-  appVersion: string;
-  protocolVersion: string;
-  appType?: AppType;
+  appVersion: string | null;
+  protocolVersion: string | null;
+  appType: AppType | null;
 }
 
-/** Persisted "user has already dismissed the warning for this companion build" marker. */
+/**
+ * Persisted dismissal marker. `appVersion` is `null` for pre-0.4.0
+ * companions (so they can be dismissed too) — when the companion later
+ * advertises a real version, that bucket no longer matches and the Alert
+ * re-appears.
+ */
 export interface DismissedCompanionVersion {
-  appVersion: string;
+  appVersion: string | null;
 }
 
 /**
@@ -86,14 +95,30 @@ export function isCompatible(actual: string, min: string): boolean {
 }
 
 /**
- * True when the extension should surface the "update your companion" warning
- * — i.e. the companion reported a `protocolVersion` below
- * `MIN_COMPATIBLE_PROTOCOL_VERSION` and the user has not dismissed the warning
- * for the companion's current `appVersion`.
+ * Raw "is the connected companion out of date?" check, ignoring any dismissal.
+ * Used to drive surfaces that should always reflect mismatch status — e.g. the
+ * popup footer's persistent "Update available" link.
  *
- * Companions that omit `protocolVersion` (pre-0.4.0 builds) are treated as
- * compatible — we don't want to spam users on older companions who haven't
- * yet had a chance to update through the normal channel.
+ * Returns `false` when no companion has connected yet (nothing to warn about).
+ *
+ * @param companion - Most recent companion info, or null if none yet seen
+ * @param minProtocolVersion - Override for the minimum compatible protocol version
+ * @returns `true` when the companion's protocol is missing or below the minimum
+ */
+export function hasVersionMismatch(
+  companion: CompanionInfo | null,
+  minProtocolVersion: string = MIN_COMPATIBLE_PROTOCOL_VERSION,
+): boolean {
+  if (!companion) return false;
+  if (!companion.protocolVersion) return true;
+  return !isCompatible(companion.protocolVersion, minProtocolVersion);
+}
+
+/**
+ * True when the popup should render the out-of-date *Alert*. Same as
+ * `hasVersionMismatch` but suppressed once the user has dismissed it for
+ * this `appVersion` bucket (`null` is its own bucket — see
+ * `DismissedCompanionVersion`).
  *
  * @param companion - Most recent companion info, or null if none yet seen
  * @param dismissed - Last dismissal record persisted in chrome.storage
@@ -105,28 +130,8 @@ export function shouldWarnAboutVersion(
   dismissed: DismissedCompanionVersion | null,
   minProtocolVersion: string = MIN_COMPATIBLE_PROTOCOL_VERSION,
 ): boolean {
-  if (!companion?.protocolVersion) return false;
-  if (isCompatible(companion.protocolVersion, minProtocolVersion)) return false;
-  return dismissed?.appVersion !== companion.appVersion;
-}
-
-/**
- * Persists the companion info captured during handshake.
- * @param info - Companion metadata to persist
- */
-export async function setCompanionInfo(info: CompanionInfo): Promise<void> {
-  await chrome.storage.local.set({ [COMPANION_INFO_STORAGE_KEY]: info });
-}
-
-/**
- * Reads the most recently captured companion info, if any.
- * @returns The persisted companion info, or null if the extension hasn't
- *   completed a handshake since install.
- */
-export async function getCompanionInfo(): Promise<CompanionInfo | null> {
-  const result = await chrome.storage.local.get(COMPANION_INFO_STORAGE_KEY);
-  const value = result[COMPANION_INFO_STORAGE_KEY] as CompanionInfo | undefined;
-  return value ?? null;
+  if (!hasVersionMismatch(companion, minProtocolVersion)) return false;
+  return dismissed?.appVersion !== companion?.appVersion;
 }
 
 /**
@@ -143,9 +148,11 @@ export async function getDismissedCompanionVersion(): Promise<DismissedCompanion
 
 /**
  * Records that the user has dismissed the warning for this companion build.
- * @param appVersion - The companion's current `appVersion` at the moment of dismissal.
+ * `null` is a valid bucket — pre-0.4.0 companions can be dismissed too, and
+ * the dismissal stops matching once the companion reports a real version.
+ * @param appVersion - The companion's current `appVersion` (or `null`) at the moment of dismissal.
  */
-export async function setDismissedCompanionVersion(appVersion: string): Promise<void> {
+export async function setDismissedCompanionVersion(appVersion: string | null): Promise<void> {
   await chrome.storage.local.set({
     [DISMISSED_COMPANION_VERSION_STORAGE_KEY]: { appVersion } satisfies DismissedCompanionVersion,
   });
@@ -157,10 +164,10 @@ export async function setDismissedCompanionVersion(appVersion: string): Promise<
  * `appType` falls through to the generic label so copy still reads naturally
  * when a newer companion sends an `appType` this extension doesn't recognise.
  *
- * @param appType - Reported by the companion, or `undefined` when absent/unknown
+ * @param appType - Reported by the companion, or `null`/`undefined` when absent/unknown
  * @returns i18n key for the companion type display label
  */
-export function companionTypeLabelKey(appType: AppType | undefined): string {
+export function companionTypeLabelKey(appType: AppType | null | undefined): string {
   if (appType === 'server') return 'about_companion_type_server';
   if (appType === 'desktop') return 'about_companion_type_desktop';
   return 'about_companion_type_generic';
@@ -170,10 +177,10 @@ export function companionTypeLabelKey(appType: AppType | undefined): string {
  * Resolves the i18n key for the Alert action button that prompts the user to
  * update the companion (`version_mismatch_action_{desktop,server,generic}`).
  *
- * @param appType - Reported by the companion, or `undefined` when absent/unknown
+ * @param appType - Reported by the companion, or `null`/`undefined` when absent/unknown
  * @returns i18n key for the action button label
  */
-export function versionMismatchActionKey(appType: AppType | undefined): string {
+export function versionMismatchActionKey(appType: AppType | null | undefined): string {
   if (appType === 'server') return 'version_mismatch_action_server';
   if (appType === 'desktop') return 'version_mismatch_action_desktop';
   return 'version_mismatch_action_generic';

--- a/apps/extension/src/locales/en.json
+++ b/apps/extension/src/locales/en.json
@@ -142,6 +142,17 @@
   "about_section_title": "About",
   "about_version": "Version {{version}}",
   "about_extension_name": "Thaumic Cast Extension",
+  "about_companion_heading": "Connected Companion",
+  "about_companion_not_connected": "No companion is currently connected",
+  "about_companion_type_desktop": "Desktop App",
+  "about_companion_type_server": "Server",
+  "about_companion_type_generic": "Companion",
+  "about_companion_protocol": "Protocol v{{version}}",
+
+  "version_mismatch_message": "Your {{appTypeLabel}} has fallen behind the extension (currently v{{appVersion}}). Update to restore harmony.",
+  "version_mismatch_action_desktop": "Update Desktop App",
+  "version_mismatch_action_server": "Update Server",
+  "version_mismatch_action_generic": "Update Companion",
 
   "loading_settings": "Loading settings...",
 

--- a/apps/extension/src/locales/en.json
+++ b/apps/extension/src/locales/en.json
@@ -11,10 +11,11 @@
   "dismiss": "Dismiss",
   "active_casts": "Active Rituals",
 
-  "desktop_app_status": "Desktop App",
-  "status_checking": "Seeking...",
-  "status_disconnected": "Absent",
-  "status_connected": "Present",
+  "connection_status_checking": "Looking for companion...",
+  "connection_status_disconnected": "Disconnected",
+  "connection_status_connected": "Connected",
+  "connection_status_connected_desktop": "Connected to Desktop App",
+  "connection_status_connected_server": "Connected to Server",
 
   "warning_reconnecting": "The connection wandered off. We're fetching it.",
 
@@ -146,13 +147,16 @@
   "about_companion_not_connected": "No companion is currently connected",
   "about_companion_type_desktop": "Desktop App",
   "about_companion_type_server": "Server",
-  "about_companion_type_generic": "Companion",
+  "about_companion_type_generic": "Desktop App or Server",
   "about_companion_protocol": "Protocol v{{version}}",
+  "about_companion_unknown_version": "Unknown version",
 
   "version_mismatch_message": "Your {{appTypeLabel}} has fallen behind the extension (currently v{{appVersion}}). Update to restore harmony.",
+  "version_mismatch_unknown_message": "Your app predates this extension and can't report its version. Update to restore harmony.",
   "version_mismatch_action_desktop": "Update Desktop App",
   "version_mismatch_action_server": "Update Server",
-  "version_mismatch_action_generic": "Update Companion",
+  "version_mismatch_action_generic": "Update",
+  "update_available": "Update available",
 
   "loading_settings": "Loading settings...",
 

--- a/apps/extension/src/offscreen/control-connection.ts
+++ b/apps/extension/src/offscreen/control-connection.ts
@@ -88,10 +88,30 @@ export function connectControlWebSocket(url: string): void {
       // INITIAL_STATE on connect
       if (message.type === 'INITIAL_STATE') {
         cachedSonosState = message.payload as SonosStateSnapshot;
+        // Forward Sonos state + companion version metadata in a single
+        // message. Combining them avoids ordering races at the background:
+        // by the time the popup re-fetches connection state in response to
+        // WS_CONNECTED, the companion fields are already populated.
+        //
+        // Pre-0.4.0 companions omit the version fields; we send nulls in
+        // that case so the popup can tell "old companion that can't report
+        // its version" apart from "never connected".
+        const payload = message.payload as {
+          appVersion?: unknown;
+          protocolVersion?: unknown;
+          appType?: unknown;
+        };
         chrome.runtime
           .sendMessage({
             type: 'WS_CONNECTED',
             state: cachedSonosState,
+            appVersion: typeof payload.appVersion === 'string' ? payload.appVersion : null,
+            protocolVersion:
+              typeof payload.protocolVersion === 'string' ? payload.protocolVersion : null,
+            appType:
+              payload.appType === 'desktop' || payload.appType === 'server'
+                ? payload.appType
+                : null,
           })
           .catch(noop);
       }

--- a/apps/extension/src/offscreen/worker-base.ts
+++ b/apps/extension/src/offscreen/worker-base.ts
@@ -655,6 +655,30 @@ export async function connectWebSocket(
             s.streamId = message.payload.streamId;
             s.log.info(`Handshake complete, streamId: ${s.streamId}`);
 
+            // Persist companion version metadata for the popup/options to display
+            // and to drive the out-of-date warning. Pre-0.4.0 companions omit
+            // these fields; we silently skip persistence so those builds continue
+            // to work without triggering a false-positive warning.
+            //
+            // `appType` is intentionally allowed to be absent — a future companion
+            // variant (e.g. `"cli"`) will be dropped to undefined by the schema's
+            // `.catch(undefined)`, and we still want the About surface and the
+            // warning to work using the version fields we *did* receive.
+            //
+            // Fire-and-forget: the popup's useStorageListener picks up the write
+            // via chrome.storage.local.onChanged on cold open, so a brief gap
+            // before storage lands is self-correcting.
+            const { appVersion, protocolVersion, appType } = message.payload;
+            if (appVersion && protocolVersion) {
+              chrome.storage.local
+                .set({
+                  companionInfo: { appVersion, protocolVersion, appType },
+                })
+                .catch((err: unknown) => {
+                  s.log.warn('Failed to persist companion info', err);
+                });
+            }
+
             startHeartbeat(s);
 
             // Set up persistent message handlers bound to this state

--- a/apps/extension/src/offscreen/worker-base.ts
+++ b/apps/extension/src/offscreen/worker-base.ts
@@ -655,29 +655,10 @@ export async function connectWebSocket(
             s.streamId = message.payload.streamId;
             s.log.info(`Handshake complete, streamId: ${s.streamId}`);
 
-            // Persist companion version metadata for the popup/options to display
-            // and to drive the out-of-date warning. Pre-0.4.0 companions omit
-            // these fields; we silently skip persistence so those builds continue
-            // to work without triggering a false-positive warning.
-            //
-            // `appType` is intentionally allowed to be absent — a future companion
-            // variant (e.g. `"cli"`) will be dropped to undefined by the schema's
-            // `.catch(undefined)`, and we still want the About surface and the
-            // warning to work using the version fields we *did* receive.
-            //
-            // Fire-and-forget: the popup's useStorageListener picks up the write
-            // via chrome.storage.local.onChanged on cold open, so a brief gap
-            // before storage lands is self-correcting.
-            const { appVersion, protocolVersion, appType } = message.payload;
-            if (appVersion && protocolVersion) {
-              chrome.storage.local
-                .set({
-                  companionInfo: { appVersion, protocolVersion, appType },
-                })
-                .catch((err: unknown) => {
-                  s.log.warn('Failed to persist companion info', err);
-                });
-            }
+            // Note: companion version metadata is persisted by the offscreen
+            // control connection (forwarded to background) when INITIAL_STATE
+            // arrives. We don't duplicate it from this audio worker because
+            // workers have no access to `chrome.*` APIs.
 
             startHeartbeat(s);
 

--- a/apps/extension/src/options/components/AboutSection.tsx
+++ b/apps/extension/src/options/components/AboutSection.tsx
@@ -4,16 +4,19 @@ import { useTranslation } from 'react-i18next';
 import { Card } from '@thaumic-cast/ui';
 import {
   COMPANION_INFO_STORAGE_KEY,
+  companionTypeLabelKey,
   type CompanionInfo,
   getCompanionInfo,
 } from '../../lib/versionCheck';
+import { useStorageListener } from '../../popup/hooks/useStorageListener';
 import styles from '../Options.module.css';
 
 /**
  * About section showing extension information and — when the extension is
  * connected to a desktop app or server — that companion's reported version
  * metadata. Values are read from `chrome.storage.local`, populated by the
- * offscreen worker on each successful handshake.
+ * offscreen worker on each successful handshake; `useStorageListener` keeps
+ * the display in sync with live handshake events.
  * @returns The about section element
  */
 export function AboutSection(): JSX.Element {
@@ -25,24 +28,9 @@ export function AboutSection(): JSX.Element {
     getCompanionInfo()
       .then(setCompanion)
       .catch(() => setCompanion(null));
-
-    const handler = (changes: { [key: string]: chrome.storage.StorageChange }) => {
-      const change = changes[COMPANION_INFO_STORAGE_KEY];
-      if (change?.newValue !== undefined) {
-        setCompanion(change.newValue as CompanionInfo);
-      }
-    };
-    chrome.storage.local.onChanged.addListener(handler);
-    return () => chrome.storage.local.onChanged.removeListener(handler);
   }, []);
 
-  const companionTypeLabel = t(
-    companion?.appType === 'server'
-      ? 'about_companion_type_server'
-      : companion?.appType === 'desktop'
-        ? 'about_companion_type_desktop'
-        : 'about_companion_type_generic',
-  );
+  useStorageListener<CompanionInfo>(COMPANION_INFO_STORAGE_KEY, setCompanion);
 
   return (
     <Card title={t('about_section_title')}>
@@ -57,7 +45,8 @@ export function AboutSection(): JSX.Element {
           {companion ? (
             <>
               <div className={styles.hint}>
-                {companionTypeLabel} · {t('about_version', { version: companion.appVersion })}
+                {t(companionTypeLabelKey(companion.appType))} ·{' '}
+                {t('about_version', { version: companion.appVersion })}
               </div>
               <div className={styles.hint}>
                 {t('about_companion_protocol', { version: companion.protocolVersion })}

--- a/apps/extension/src/options/components/AboutSection.tsx
+++ b/apps/extension/src/options/components/AboutSection.tsx
@@ -1,36 +1,38 @@
 import type { JSX } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
+import { useCallback } from 'preact/hooks';
 import { useTranslation } from 'react-i18next';
-import { Card } from '@thaumic-cast/ui';
-import {
-  COMPANION_INFO_STORAGE_KEY,
-  companionTypeLabelKey,
-  type CompanionInfo,
-  getCompanionInfo,
-} from '../../lib/versionCheck';
-import { useStorageListener } from '../../popup/hooks/useStorageListener';
+import { Button, Card } from '@thaumic-cast/ui';
+import { GITHUB_RELEASES_URL } from '@thaumic-cast/shared';
+import { companionTypeLabelKey, hasVersionMismatch } from '../../lib/versionCheck';
+import { useConnectionStatus } from '../../popup/hooks/useConnectionStatus';
 import styles from '../Options.module.css';
 
 /**
  * About section showing extension information and — when the extension is
  * connected to a desktop app or server — that companion's reported version
- * metadata. Values are read from `chrome.storage.local`, populated by the
- * offscreen worker on each successful handshake; `useStorageListener` keeps
- * the display in sync with live handshake events.
+ * metadata. Reads from `useConnectionStatus` (backed by `connectionState`),
+ * which is populated by `/health` at discovery and `INITIAL_STATE` on
+ * WebSocket connect.
  * @returns The about section element
  */
 export function AboutSection(): JSX.Element {
   const { t } = useTranslation();
   const version = chrome.runtime.getManifest().version;
-  const [companion, setCompanion] = useState<CompanionInfo | null>(null);
+  const connection = useConnectionStatus();
 
-  useEffect(() => {
-    getCompanionInfo()
-      .then(setCompanion)
-      .catch(() => setCompanion(null));
+  const handleOpenReleases = useCallback(() => {
+    chrome.tabs.create({ url: GITHUB_RELEASES_URL });
   }, []);
 
-  useStorageListener<CompanionInfo>(COMPANION_INFO_STORAGE_KEY, setCompanion);
+  const isConnected = connection.phase === 'connected';
+  const companion = isConnected
+    ? {
+        appType: connection.appType,
+        appVersion: connection.appVersion,
+        protocolVersion: connection.protocolVersion,
+      }
+    : null;
+  const mismatch = hasVersionMismatch(companion);
 
   return (
     <Card title={t('about_section_title')}>
@@ -43,15 +45,37 @@ export function AboutSection(): JSX.Element {
         <div>
           <div style={{ fontWeight: 500 }}>{t('about_companion_heading')}</div>
           {companion ? (
-            <>
+            companion.appVersion && companion.protocolVersion ? (
+              <>
+                <div className={styles.hint}>
+                  {t(companionTypeLabelKey(companion.appType))} ·{' '}
+                  {t('about_version', { version: companion.appVersion })}
+                  {mismatch && (
+                    <>
+                      {' · '}
+                      <Button variant="link" onClick={handleOpenReleases}>
+                        {t('update_available')}
+                      </Button>
+                    </>
+                  )}
+                </div>
+                <div className={styles.hint}>
+                  {t('about_companion_protocol', { version: companion.protocolVersion })}
+                </div>
+              </>
+            ) : (
               <div className={styles.hint}>
-                {t(companionTypeLabelKey(companion.appType))} ·{' '}
-                {t('about_version', { version: companion.appVersion })}
+                {t('about_companion_unknown_version')}
+                {mismatch && (
+                  <>
+                    {' · '}
+                    <Button variant="link" onClick={handleOpenReleases}>
+                      {t('update_available')}
+                    </Button>
+                  </>
+                )}
               </div>
-              <div className={styles.hint}>
-                {t('about_companion_protocol', { version: companion.protocolVersion })}
-              </div>
-            </>
+            )
           ) : (
             <div className={styles.hint}>{t('about_companion_not_connected')}</div>
           )}

--- a/apps/extension/src/options/components/AboutSection.tsx
+++ b/apps/extension/src/options/components/AboutSection.tsx
@@ -1,15 +1,48 @@
 import type { JSX } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
 import { useTranslation } from 'react-i18next';
 import { Card } from '@thaumic-cast/ui';
+import {
+  COMPANION_INFO_STORAGE_KEY,
+  type CompanionInfo,
+  getCompanionInfo,
+} from '../../lib/versionCheck';
 import styles from '../Options.module.css';
 
 /**
- * About section showing extension information.
+ * About section showing extension information and — when the extension is
+ * connected to a desktop app or server — that companion's reported version
+ * metadata. Values are read from `chrome.storage.local`, populated by the
+ * offscreen worker on each successful handshake.
  * @returns The about section element
  */
 export function AboutSection(): JSX.Element {
   const { t } = useTranslation();
   const version = chrome.runtime.getManifest().version;
+  const [companion, setCompanion] = useState<CompanionInfo | null>(null);
+
+  useEffect(() => {
+    getCompanionInfo()
+      .then(setCompanion)
+      .catch(() => setCompanion(null));
+
+    const handler = (changes: { [key: string]: chrome.storage.StorageChange }) => {
+      const change = changes[COMPANION_INFO_STORAGE_KEY];
+      if (change?.newValue !== undefined) {
+        setCompanion(change.newValue as CompanionInfo);
+      }
+    };
+    chrome.storage.local.onChanged.addListener(handler);
+    return () => chrome.storage.local.onChanged.removeListener(handler);
+  }, []);
+
+  const companionTypeLabel = t(
+    companion?.appType === 'server'
+      ? 'about_companion_type_server'
+      : companion?.appType === 'desktop'
+        ? 'about_companion_type_desktop'
+        : 'about_companion_type_generic',
+  );
 
   return (
     <Card title={t('about_section_title')}>
@@ -17,6 +50,22 @@ export function AboutSection(): JSX.Element {
         <div>
           <div style={{ fontWeight: 500 }}>{t('about_extension_name')}</div>
           <div className={styles.hint}>{t('about_version', { version })}</div>
+        </div>
+
+        <div>
+          <div style={{ fontWeight: 500 }}>{t('about_companion_heading')}</div>
+          {companion ? (
+            <>
+              <div className={styles.hint}>
+                {companionTypeLabel} · {t('about_version', { version: companion.appVersion })}
+              </div>
+              <div className={styles.hint}>
+                {t('about_companion_protocol', { version: companion.protocolVersion })}
+              </div>
+            </>
+          ) : (
+            <div className={styles.hint}>{t('about_companion_not_connected')}</div>
+          )}
         </div>
       </div>
     </Card>

--- a/apps/extension/src/popup/App.tsx
+++ b/apps/extension/src/popup/App.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback, useMemo } from 'preact/hooks';
 import { useTranslation } from 'react-i18next';
 import { SPEAKER_AVAILABILITY_LABELS, MediaAction } from '@thaumic-cast/protocol';
 import { getSpeakerAvailability } from '@thaumic-cast/protocol';
+import { GITHUB_RELEASES_URL } from '@thaumic-cast/shared';
 import { Radio, Settings } from 'lucide-preact';
 import { Alert, IconButton } from '@thaumic-cast/ui';
 import styles from './App.module.css';
@@ -23,6 +24,7 @@ import { useConnectionStatus } from './hooks/useConnectionStatus';
 import { useOnboarding } from './hooks/useOnboarding';
 import { useExtensionSettingsListener } from './hooks/useExtensionSettingsListener';
 import { useSpeakerSelection } from './hooks/useSpeakerSelection';
+import { useCompanionVersion } from './hooks/useCompanionVersion';
 import { Onboarding } from './components/Onboarding';
 
 /**
@@ -116,6 +118,28 @@ function MainPopup(): JSX.Element {
   // Auto-stop notification hook
   const { notification: autoStopNotification, message: autoStopMessage } =
     useAutoStopNotification();
+
+  // Companion version mismatch warning
+  const { companion, showMismatchWarning, dismissMismatchWarning } = useCompanionVersion();
+
+  const handleOpenReleases = useCallback(() => {
+    chrome.tabs.create({ url: GITHUB_RELEASES_URL });
+  }, []);
+
+  const mismatchActionKey =
+    companion?.appType === 'server'
+      ? 'version_mismatch_action_server'
+      : companion?.appType === 'desktop'
+        ? 'version_mismatch_action_desktop'
+        : 'version_mismatch_action_generic';
+
+  const mismatchAppTypeLabel = t(
+    companion?.appType === 'server'
+      ? 'about_companion_type_server'
+      : companion?.appType === 'desktop'
+        ? 'about_companion_type_desktop'
+        : 'about_companion_type_generic',
+  );
 
   // Show auto-stop notification as error
   useEffect(() => {
@@ -264,6 +288,21 @@ function MainPopup(): JSX.Element {
       {connectionPhase === 'reconnecting' && (
         <Alert variant="warning" className={styles.alert}>
           {t('warning_reconnecting')}
+        </Alert>
+      )}
+
+      {showMismatchWarning && companion && (
+        <Alert
+          variant="warning"
+          className={styles.alert}
+          action={t(mismatchActionKey)}
+          onAction={handleOpenReleases}
+          onDismiss={dismissMismatchWarning}
+        >
+          {t('version_mismatch_message', {
+            appTypeLabel: mismatchAppTypeLabel,
+            appVersion: companion.appVersion,
+          })}
         </Alert>
       )}
 

--- a/apps/extension/src/popup/App.tsx
+++ b/apps/extension/src/popup/App.tsx
@@ -25,6 +25,7 @@ import { useOnboarding } from './hooks/useOnboarding';
 import { useExtensionSettingsListener } from './hooks/useExtensionSettingsListener';
 import { useSpeakerSelection } from './hooks/useSpeakerSelection';
 import { useCompanionVersion } from './hooks/useCompanionVersion';
+import { companionTypeLabelKey, versionMismatchActionKey } from '../lib/versionCheck';
 import { Onboarding } from './components/Onboarding';
 
 /**
@@ -126,20 +127,8 @@ function MainPopup(): JSX.Element {
     chrome.tabs.create({ url: GITHUB_RELEASES_URL });
   }, []);
 
-  const mismatchActionKey =
-    companion?.appType === 'server'
-      ? 'version_mismatch_action_server'
-      : companion?.appType === 'desktop'
-        ? 'version_mismatch_action_desktop'
-        : 'version_mismatch_action_generic';
-
-  const mismatchAppTypeLabel = t(
-    companion?.appType === 'server'
-      ? 'about_companion_type_server'
-      : companion?.appType === 'desktop'
-        ? 'about_companion_type_desktop'
-        : 'about_companion_type_generic',
-  );
+  const mismatchActionKey = versionMismatchActionKey(companion?.appType);
+  const mismatchAppTypeLabel = t(companionTypeLabelKey(companion?.appType));
 
   // Show auto-stop notification as error
   useEffect(() => {

--- a/apps/extension/src/popup/App.tsx
+++ b/apps/extension/src/popup/App.tsx
@@ -5,7 +5,7 @@ import { SPEAKER_AVAILABILITY_LABELS, MediaAction } from '@thaumic-cast/protocol
 import { getSpeakerAvailability } from '@thaumic-cast/protocol';
 import { GITHUB_RELEASES_URL } from '@thaumic-cast/shared';
 import { Radio, Settings } from 'lucide-preact';
-import { Alert, IconButton } from '@thaumic-cast/ui';
+import { Alert, Button, IconButton } from '@thaumic-cast/ui';
 import styles from './App.module.css';
 import type {
   ExtensionResponse,
@@ -65,6 +65,7 @@ function MainPopup(): JSX.Element {
   const { videoSyncEnabled } = useExtensionSettingsListener();
 
   // Connection status with instant cached display
+  const connection = useConnectionStatus();
   const {
     phase: connectionPhase,
     error: connectionError,
@@ -73,7 +74,7 @@ function MainPopup(): JSX.Element {
     networkHealth,
     networkHealthReason,
     retry: handleRetryConnection,
-  } = useConnectionStatus();
+  } = connection;
 
   // Derived states for convenience
   const wsConnected = connectionPhase === 'connected';
@@ -121,7 +122,8 @@ function MainPopup(): JSX.Element {
     useAutoStopNotification();
 
   // Companion version mismatch warning
-  const { companion, showMismatchWarning, dismissMismatchWarning } = useCompanionVersion();
+  const { companion, hasMismatch, showMismatchWarning, dismissMismatchWarning } =
+    useCompanionVersion(connection);
 
   const handleOpenReleases = useCallback(() => {
     chrome.tabs.create({ url: GITHUB_RELEASES_URL });
@@ -288,10 +290,12 @@ function MainPopup(): JSX.Element {
           onAction={handleOpenReleases}
           onDismiss={dismissMismatchWarning}
         >
-          {t('version_mismatch_message', {
-            appTypeLabel: mismatchAppTypeLabel,
-            appVersion: companion.appVersion,
-          })}
+          {companion.appVersion
+            ? t('version_mismatch_message', {
+                appTypeLabel: mismatchAppTypeLabel,
+                appVersion: companion.appVersion,
+              })
+            : t('version_mismatch_unknown_message')}
         </Alert>
       )}
 
@@ -360,12 +364,26 @@ function MainPopup(): JSX.Element {
       )}
 
       <p className={styles.footer}>
-        {t('desktop_app_status')}:{' '}
         <span className={`${styles.status} ${getStatusClass()}`}>
-          {isSeeking && t('status_checking')}
-          {connectionPhase === 'connected' && t('status_connected')}
-          {connectionPhase === 'error' && t('status_disconnected')}
+          {isSeeking && t('connection_status_checking')}
+          {connectionPhase === 'connected' &&
+            t(
+              connection.appType === 'desktop'
+                ? 'connection_status_connected_desktop'
+                : connection.appType === 'server'
+                  ? 'connection_status_connected_server'
+                  : 'connection_status_connected',
+            )}
+          {connectionPhase === 'error' && t('connection_status_disconnected')}
         </span>
+        {hasMismatch && wsConnected && (
+          <>
+            {' · '}
+            <Button variant="link" onClick={handleOpenReleases}>
+              {t('update_available')}
+            </Button>
+          </>
+        )}
       </p>
     </div>
   );

--- a/apps/extension/src/popup/components/onboarding/DesktopConnectionStep.tsx
+++ b/apps/extension/src/popup/components/onboarding/DesktopConnectionStep.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'preact/hooks';
 import { WizardStep, Alert, Button, Disclosure, Input } from '@thaumic-cast/ui';
 import { Monitor, Download, RefreshCw } from 'lucide-preact';
 import { useTranslation } from 'react-i18next';
+import { GITHUB_RELEASES_URL } from '@thaumic-cast/shared';
 import { useConnectionStatus } from '../../hooks/useConnectionStatus';
 import {
   testServerConnection,
@@ -46,7 +47,7 @@ export function DesktopConnectionStep({
 
   const handleDownload = () => {
     // Open releases page in new tab
-    chrome.tabs.create({ url: 'https://github.com/brew-lab/thaumic-cast/releases/latest' });
+    chrome.tabs.create({ url: GITHUB_RELEASES_URL });
   };
 
   /**

--- a/apps/extension/src/popup/hooks/useCompanionVersion.ts
+++ b/apps/extension/src/popup/hooks/useCompanionVersion.ts
@@ -1,0 +1,67 @@
+/**
+ * Companion version hook.
+ *
+ * Reads the most recent companion info (persisted by the offscreen worker on
+ * handshake) and the user's latest dismissal, derives whether to show the
+ * out-of-date warning, and exposes a callback to dismiss the warning for the
+ * current companion build.
+ */
+
+import { useCallback, useEffect, useState } from 'preact/hooks';
+import {
+  COMPANION_INFO_STORAGE_KEY,
+  DISMISSED_COMPANION_VERSION_STORAGE_KEY,
+  type CompanionInfo,
+  type DismissedCompanionVersion,
+  getCompanionInfo,
+  getDismissedCompanionVersion,
+  setDismissedCompanionVersion,
+  shouldWarnAboutVersion,
+} from '../../lib/versionCheck';
+import { useStorageListener } from './useStorageListener';
+
+export interface UseCompanionVersionResult {
+  companion: CompanionInfo | null;
+  showMismatchWarning: boolean;
+  dismissMismatchWarning: () => void;
+}
+
+/**
+ * Reads the connected companion's version metadata and derives whether the
+ * popup should render the out-of-date warning.
+ * @returns Companion info, the warning flag, and a dismissal callback
+ */
+export function useCompanionVersion(): UseCompanionVersionResult {
+  const [companion, setCompanion] = useState<CompanionInfo | null>(null);
+  const [dismissed, setDismissed] = useState<DismissedCompanionVersion | null>(null);
+
+  useEffect(() => {
+    getCompanionInfo()
+      .then(setCompanion)
+      .catch(() => setCompanion(null));
+    getDismissedCompanionVersion()
+      .then(setDismissed)
+      .catch(() => setDismissed(null));
+  }, []);
+
+  useStorageListener<CompanionInfo>(COMPANION_INFO_STORAGE_KEY, setCompanion);
+  useStorageListener<DismissedCompanionVersion>(
+    DISMISSED_COMPANION_VERSION_STORAGE_KEY,
+    setDismissed,
+  );
+
+  const dismissMismatchWarning = useCallback(() => {
+    if (!companion?.appVersion) return;
+    const appVersion = companion.appVersion;
+    setDismissed({ appVersion });
+    setDismissedCompanionVersion(appVersion).catch(() => {
+      // Ignore — next handshake will re-derive state anyway.
+    });
+  }, [companion?.appVersion]);
+
+  return {
+    companion,
+    showMismatchWarning: shouldWarnAboutVersion(companion, dismissed),
+    dismissMismatchWarning,
+  };
+}

--- a/apps/extension/src/popup/hooks/useCompanionVersion.ts
+++ b/apps/extension/src/popup/hooks/useCompanionVersion.ts
@@ -1,66 +1,81 @@
 /**
  * Companion version hook.
  *
- * Reads the most recent companion info (persisted by the offscreen worker on
- * handshake) and the user's latest dismissal, derives whether to show the
- * out-of-date warning, and exposes a callback to dismiss the warning for the
- * current companion build.
+ * Reads companion fields straight off the connection status (which itself
+ * reads from `connectionState`), reads the user's latest dismissal, derives
+ * whether to show the out-of-date warning, and exposes a callback to
+ * dismiss the warning for the current companion build.
  */
 
 import { useCallback, useEffect, useState } from 'preact/hooks';
 import {
-  COMPANION_INFO_STORAGE_KEY,
   DISMISSED_COMPANION_VERSION_STORAGE_KEY,
   type CompanionInfo,
   type DismissedCompanionVersion,
-  getCompanionInfo,
   getDismissedCompanionVersion,
+  hasVersionMismatch,
   setDismissedCompanionVersion,
   shouldWarnAboutVersion,
 } from '../../lib/versionCheck';
 import { useStorageListener } from './useStorageListener';
+import type { ConnectionStatus } from './useConnectionStatus';
 
 export interface UseCompanionVersionResult {
   companion: CompanionInfo | null;
+  /**
+   * Raw "is the companion out of date?" — true regardless of whether the
+   * Alert has been dismissed. Drives the persistent footer "Update available"
+   * link.
+   */
+  hasMismatch: boolean;
+  /** Whether the popup should currently render the dismissible Alert. */
   showMismatchWarning: boolean;
+  /** Dismisses the Alert for the companion's current `appVersion` bucket. */
   dismissMismatchWarning: () => void;
 }
 
 /**
- * Reads the connected companion's version metadata and derives whether the
- * popup should render the out-of-date warning.
- * @returns Companion info, the warning flag, and a dismissal callback
+ * Derives companion-info-related UI flags from the connection status.
+ * @param connection - Current connection status (from `useConnectionStatus`)
+ * @returns Companion info, the warning flags, and a dismissal callback
  */
-export function useCompanionVersion(): UseCompanionVersionResult {
-  const [companion, setCompanion] = useState<CompanionInfo | null>(null);
+export function useCompanionVersion(connection: ConnectionStatus): UseCompanionVersionResult {
   const [dismissed, setDismissed] = useState<DismissedCompanionVersion | null>(null);
 
   useEffect(() => {
-    getCompanionInfo()
-      .then(setCompanion)
-      .catch(() => setCompanion(null));
     getDismissedCompanionVersion()
       .then(setDismissed)
       .catch(() => setDismissed(null));
   }, []);
 
-  useStorageListener<CompanionInfo>(COMPANION_INFO_STORAGE_KEY, setCompanion);
   useStorageListener<DismissedCompanionVersion>(
     DISMISSED_COMPANION_VERSION_STORAGE_KEY,
     setDismissed,
   );
 
+  // Build a CompanionInfo only when we have a live connection. Without one,
+  // the version-check helpers should treat the popup as "no companion seen
+  // yet" — the connection-state fields are stale until reconnect.
+  const companion: CompanionInfo | null = connection.desktopAppUrl
+    ? {
+        appType: connection.appType,
+        appVersion: connection.appVersion,
+        protocolVersion: connection.protocolVersion,
+      }
+    : null;
+
   const dismissMismatchWarning = useCallback(() => {
-    if (!companion?.appVersion) return;
-    const appVersion = companion.appVersion;
+    if (!companion) return;
+    const appVersion = companion.appVersion ?? null;
     setDismissed({ appVersion });
     setDismissedCompanionVersion(appVersion).catch(() => {
-      // Ignore — next handshake will re-derive state anyway.
+      // Ignore — next reconnect will re-derive state anyway.
     });
-  }, [companion?.appVersion]);
+  }, [companion]);
 
   return {
     companion,
+    hasMismatch: hasVersionMismatch(companion),
     showMismatchWarning: shouldWarnAboutVersion(companion, dismissed),
     dismissMismatchWarning,
   };

--- a/apps/extension/src/popup/hooks/useConnectionStatus.ts
+++ b/apps/extension/src/popup/hooks/useConnectionStatus.ts
@@ -1,4 +1,5 @@
 import { useReducer, useEffect, useCallback } from 'preact/hooks';
+import type { AppType } from '@thaumic-cast/protocol';
 import type { ConnectionState as BackgroundConnectionState } from '../../background/connection-state';
 import type { EnsureConnectionResponse } from '../../lib/messages';
 import { useChromeMessage } from './useChromeMessage';
@@ -34,6 +35,12 @@ export interface ConnectionStatus {
   networkHealth: NetworkHealthStatus;
   /** Reason for degraded network health (null if healthy) */
   networkHealthReason: string | null;
+  /** Companion type from `/health` (null on pre-0.4.0 builds). */
+  appType: AppType | null;
+  /** Companion app semver from `INITIAL_STATE` (null on pre-0.4.0 builds). */
+  appVersion: string | null;
+  /** Wire-protocol semver from `INITIAL_STATE` (null on pre-0.4.0 builds). */
+  protocolVersion: string | null;
   /** Triggers a connection retry attempt (sets phase to 'checking') */
   retry: () => Promise<void>;
 }
@@ -47,6 +54,9 @@ interface ConnectionState {
   maxStreams: number | null;
   networkHealth: NetworkHealthStatus;
   networkHealthReason: string | null;
+  appType: AppType | null;
+  appVersion: string | null;
+  protocolVersion: string | null;
 }
 
 /** Actions that can update connection state */
@@ -69,6 +79,9 @@ const initialState: ConnectionState = {
   maxStreams: null,
   networkHealth: 'ok',
   networkHealthReason: null,
+  appType: null,
+  appVersion: null,
+  protocolVersion: null,
 };
 
 /**
@@ -103,6 +116,9 @@ function connectionReducer(state: ConnectionState, action: ConnectionAction): Co
         maxStreams,
         networkHealth,
         networkHealthReason,
+        appType,
+        appVersion,
+        protocolVersion,
       } = action.payload;
       if (!desktopAppUrl) return state;
       return {
@@ -114,6 +130,9 @@ function connectionReducer(state: ConnectionState, action: ConnectionAction): Co
         maxStreams,
         networkHealth: networkHealth ?? 'ok',
         networkHealthReason: networkHealthReason ?? null,
+        appType: appType ?? null,
+        appVersion: appVersion ?? null,
+        protocolVersion: protocolVersion ?? null,
       };
     }
 

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -13,7 +13,8 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use parking_lot::RwLock;
 use thaumic_core::{
-    bootstrap_services_with_network, start_server, AppState, LocalIpDetector, NetworkContext,
+    bootstrap_services_with_network, start_server, AppInfo, AppState, AppType, LocalIpDetector,
+    NetworkContext,
 };
 use tokio::signal;
 
@@ -120,6 +121,7 @@ async fn main() -> Result<()> {
         &services,
         Arc::new(RwLock::new(core_config)),
         config.to_artwork_config(),
+        AppInfo::new(env!("CARGO_PKG_VERSION"), AppType::Server),
     );
 
     // Spawn HTTP server on the main tokio runtime.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thaumic-cast/protocol",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "author": {
     "name": "Brew",

--- a/packages/protocol/src/sonos.ts
+++ b/packages/protocol/src/sonos.ts
@@ -95,7 +95,16 @@ export function createEmptySonosState(): SonosStateSnapshot {
 
 /**
  * Initial state message sent by desktop on WebSocket connect.
- * Includes Sonos state.
+ *
+ * Carries Sonos state plus the same companion version metadata exchanged in
+ * the streaming HANDSHAKE_ACK. The control connection runs on every connect
+ * — even when the user never starts a stream — so this is what lets the
+ * extension surface the out-of-date warning before the first cast.
+ *
+ * The version fields use `.catch(undefined)` for the same reason as the
+ * handshake ACK: a future companion may report values an older extension
+ * doesn't recognise (e.g. an `appType: "cli"`), and we don't want a single
+ * unrecognised field to drop the whole payload.
  */
 export const InitialStatePayloadSchema = z.object({
   groups: z.array(ZoneGroupSchema),
@@ -104,6 +113,16 @@ export const InitialStatePayloadSchema = z.object({
   groupMutes: z.record(z.string(), z.boolean()),
   groupVolumeFixed: z.record(z.string(), z.boolean()),
   sessions: z.array(PlaybackSessionSchema).optional(),
+  /** Wire-protocol semver — absent on companions predating 0.4.0. */
+  protocolVersion: z.string().optional().catch(undefined),
+  /** Companion app semver — absent on companions predating 0.4.0. */
+  appVersion: z.string().optional().catch(undefined),
+  /**
+   * Which companion the extension is talking to — absent on pre-0.4.0
+   * companions, and degraded to `undefined` for any future variant
+   * this extension doesn't recognise (e.g. `"cli"`).
+   */
+  appType: z.enum(['desktop', 'server']).optional().catch(undefined),
 });
 export type InitialStatePayload = z.infer<typeof InitialStatePayloadSchema>;
 

--- a/packages/protocol/src/websocket.ts
+++ b/packages/protocol/src/websocket.ts
@@ -18,7 +18,12 @@ import { StreamMetadataSchema } from './stream.js';
  */
 export const PROTOCOL_VERSION = '0.4.0' as const;
 
-/** Which companion process sent the handshake ACK. */
+/**
+ * Which companion process advertised the connection.
+ *
+ * Reported in `INITIAL_STATE` (sent on every WS connect) so the extension can
+ * tailor update-prompt copy to "desktop" vs. "server".
+ */
 export const AppTypeSchema = z.enum(['desktop', 'server']);
 export type AppType = z.infer<typeof AppTypeSchema>;
 
@@ -32,22 +37,6 @@ export type WsHandshakePayload = z.infer<typeof WsHandshakePayloadSchema>;
 
 export const WsHandshakeAckPayloadSchema = z.object({
   streamId: z.string(),
-  /**
-   * Wire-protocol semver reported by the companion. Absent on companions predating
-   * `@thaumic-cast/protocol` 0.4.0 — the extension should treat absence as "unknown,
-   * assume compatible" rather than erroring. Malformed values degrade to undefined
-   * via `.catch()` so an older extension never drops the whole handshake over a
-   * field it doesn't recognise.
-   */
-  protocolVersion: z.string().optional().catch(undefined),
-  /** Companion app semver, shown in the extension's About surface. */
-  appVersion: z.string().optional().catch(undefined),
-  /**
-   * Which companion the extension is talking to — affects update-prompt copy.
-   * Unknown app types (e.g. a future `"cli"` variant) degrade to undefined so
-   * the handshake still succeeds and playback works.
-   */
-  appType: AppTypeSchema.optional().catch(undefined),
 });
 export type WsHandshakeAckPayload = z.infer<typeof WsHandshakeAckPayloadSchema>;
 

--- a/packages/protocol/src/websocket.ts
+++ b/packages/protocol/src/websocket.ts
@@ -6,6 +6,23 @@ import { InitialStatePayloadSchema } from './sonos.js';
 import { StreamMetadataSchema } from './stream.js';
 
 /**
+ * Wire-protocol version advertised by this package. The companion (desktop/server)
+ * includes this in its handshake ACK so the extension can detect incompatible
+ * versions.
+ *
+ * This value is kept in sync with `packages/protocol/package.json`'s `version`
+ * by `scripts/sync-versions.ts` (invoked at release time via
+ * `bun run changeset:version`). Do not edit by hand; see CONTRIBUTING.md →
+ * Protocol versioning for the bump policy and the relationship with
+ * `MIN_COMPATIBLE_PROTOCOL_VERSION`.
+ */
+export const PROTOCOL_VERSION = '0.4.0' as const;
+
+/** Which companion process sent the handshake ACK. */
+export const AppTypeSchema = z.enum(['desktop', 'server']);
+export type AppType = z.infer<typeof AppTypeSchema>;
+
+/**
  * WebSocket Message Payloads
  */
 export const WsHandshakePayloadSchema = z.object({
@@ -15,6 +32,22 @@ export type WsHandshakePayload = z.infer<typeof WsHandshakePayloadSchema>;
 
 export const WsHandshakeAckPayloadSchema = z.object({
   streamId: z.string(),
+  /**
+   * Wire-protocol semver reported by the companion. Absent on companions predating
+   * `@thaumic-cast/protocol` 0.4.0 — the extension should treat absence as "unknown,
+   * assume compatible" rather than erroring. Malformed values degrade to undefined
+   * via `.catch()` so an older extension never drops the whole handshake over a
+   * field it doesn't recognise.
+   */
+  protocolVersion: z.string().optional().catch(undefined),
+  /** Companion app semver, shown in the extension's About surface. */
+  appVersion: z.string().optional().catch(undefined),
+  /**
+   * Which companion the extension is talking to — affects update-prompt copy.
+   * Unknown app types (e.g. a future `"cli"` variant) degrade to undefined so
+   * the handshake still succeeds and playback works.
+   */
+  appType: AppTypeSchema.optional().catch(undefined),
 });
 export type WsHandshakeAckPayload = z.infer<typeof WsHandshakeAckPayloadSchema>;
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,0 +1,22 @@
+/**
+ * Cross-cutting constants shared between the extension, desktop app, and server UIs.
+ */
+
+/**
+ * Canonical GitHub releases page — the single update destination for users who need
+ * to grab a newer desktop app or server build. Keep hardcoded and literal so no
+ * remote resolution is ever required (PRIVACY.md relies on this).
+ */
+export const GITHUB_RELEASES_URL = 'https://github.com/brew-lab/thaumic-cast/releases/latest';
+
+/**
+ * Minimum wire-protocol semver the extension requires from the companion
+ * (desktop app or headless server) to stream without known-broken behaviour.
+ *
+ * Bump this in lockstep with a breaking change to `@thaumic-cast/protocol`'s
+ * exported `PROTOCOL_VERSION`. If an older companion reports a version below
+ * this, the extension surfaces a dismissible "update" prompt in the popup.
+ *
+ * See `CONTRIBUTING.md` for the bump policy.
+ */
+export const MIN_COMPATIBLE_PROTOCOL_VERSION = '0.4.0';

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -12,11 +12,10 @@ export const GITHUB_RELEASES_URL = 'https://github.com/brew-lab/thaumic-cast/rel
 /**
  * Minimum wire-protocol semver the extension requires from the companion
  * (desktop app or headless server) to stream without known-broken behaviour.
+ * If an older companion reports a version below this, the extension surfaces
+ * a dismissible "update" prompt in the popup.
  *
- * Bump this in lockstep with a breaking change to `@thaumic-cast/protocol`'s
- * exported `PROTOCOL_VERSION`. If an older companion reports a version below
- * this, the extension surfaces a dismissible "update" prompt in the popup.
- *
- * See `CONTRIBUTING.md` for the bump policy.
+ * See `CONTRIBUTING.md` → Protocol versioning for when and how to bump this;
+ * the policy lives there so it can't drift from this comment.
  */
 export const MIN_COMPATIBLE_PROTOCOL_VERSION = '0.4.0';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './logger';
+export * from './constants';

--- a/packages/thaumic-core/README.md
+++ b/packages/thaumic-core/README.md
@@ -53,9 +53,14 @@ let services = bootstrap_services_with_network(&Config::default(), network, hand
 ### Starting the Server
 
 ```rust
-use thaumic_core::{AppState, ArtworkConfig, start_server};
+use thaumic_core::{AppInfo, AppState, AppType, ArtworkConfig, start_server};
 
-let app_state = AppState::new(&services, config, ArtworkConfig::default());
+let app_state = AppState::new(
+    &services,
+    config,
+    ArtworkConfig::default(),
+    AppInfo::new(env!("CARGO_PKG_VERSION"), AppType::Server),
+);
 
 start_server(app_state).await?;
 ```

--- a/packages/thaumic-core/src/api/http.rs
+++ b/packages/thaumic-core/src/api/http.rs
@@ -141,11 +141,16 @@ pub fn create_router(state: AppState) -> Router {
 ///
 /// Always returns 200 OK if the server is responding. Use `/ready` for
 /// readiness checks that verify the service can handle requests.
+///
+/// `appType` lets the extension tailor update-prompt copy ("Update Desktop
+/// App" vs. "Update Server") immediately at discovery time, without waiting
+/// for the WebSocket `INITIAL_STATE` to arrive.
 async fn health_check(State(state): State<AppState>) -> impl IntoResponse {
     let max_streams = state.config.read().streaming.max_concurrent_streams;
     api_success(json!({
         "status": "ok",
         "service": SERVICE_ID,
+        "appType": state.app_info.app_type,
         "limits": {
             "maxStreams": max_streams
         }

--- a/packages/thaumic-core/src/api/mod.rs
+++ b/packages/thaumic-core/src/api/mod.rs
@@ -19,7 +19,6 @@ use crate::capture::CaptureSourceFactory;
 use crate::context::NetworkContext;
 use crate::events::BroadcastEventBridge;
 use crate::mdns_advertise::MdnsAdvertiser;
-use crate::protocol_constants::PROTOCOL_VERSION;
 use crate::services::{DiscoveryService, LatencyMonitor, StreamCoordinator};
 use crate::sonos::SonosClient;
 use crate::state::{Config, SonosState};
@@ -46,27 +45,25 @@ pub enum AppType {
 /// Version metadata reported to the extension via the WebSocket handshake.
 ///
 /// The desktop app and headless server each construct this from their own
-/// `env!("CARGO_PKG_VERSION")` and pass it to [`AppState::new`].
-#[derive(Debug, Clone)]
+/// `env!("CARGO_PKG_VERSION")` — a compile-time `&'static str` — and pass
+/// it to [`AppState::new`], so we hold the version as `&'static str` rather
+/// than `String` to avoid a per-handshake allocation.
+#[derive(Debug, Clone, Copy)]
 pub struct AppInfo {
     /// Semver of the companion app (`apps/desktop` or `apps/server`).
-    pub app_version: String,
+    pub app_version: &'static str,
     /// Which companion is running.
     pub app_type: AppType,
 }
 
 impl AppInfo {
-    pub fn new(app_version: impl Into<String>, app_type: AppType) -> Self {
+    /// Builds the metadata block for a companion at `app_version` of type `app_type`.
+    #[must_use]
+    pub const fn new(app_version: &'static str, app_type: AppType) -> Self {
         Self {
-            app_version: app_version.into(),
+            app_version,
             app_type,
         }
-    }
-
-    /// The wire-protocol version baked into this crate — kept in sync with
-    /// `@thaumic-cast/protocol`'s exported `PROTOCOL_VERSION`.
-    pub fn protocol_version(&self) -> &'static str {
-        PROTOCOL_VERSION
     }
 }
 

--- a/packages/thaumic-core/src/api/mod.rs
+++ b/packages/thaumic-core/src/api/mod.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use parking_lot::RwLock;
+use serde::Serialize;
 use thiserror::Error;
 
 use axum::serve::ListenerExt;
@@ -18,6 +19,7 @@ use crate::capture::CaptureSourceFactory;
 use crate::context::NetworkContext;
 use crate::events::BroadcastEventBridge;
 use crate::mdns_advertise::MdnsAdvertiser;
+use crate::protocol_constants::PROTOCOL_VERSION;
 use crate::services::{DiscoveryService, LatencyMonitor, StreamCoordinator};
 use crate::sonos::SonosClient;
 use crate::state::{Config, SonosState};
@@ -29,6 +31,44 @@ pub mod ws;
 pub mod ws_connection;
 
 pub use ws_connection::WsConnectionManager;
+
+/// Identifies which companion process is serving the WebSocket API.
+///
+/// Reported to the extension in the handshake ACK so update-prompt copy
+/// can be tailored ("update desktop app" vs. "update server").
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AppType {
+    Desktop,
+    Server,
+}
+
+/// Version metadata reported to the extension via the WebSocket handshake.
+///
+/// The desktop app and headless server each construct this from their own
+/// `env!("CARGO_PKG_VERSION")` and pass it to [`AppState::new`].
+#[derive(Debug, Clone)]
+pub struct AppInfo {
+    /// Semver of the companion app (`apps/desktop` or `apps/server`).
+    pub app_version: String,
+    /// Which companion is running.
+    pub app_type: AppType,
+}
+
+impl AppInfo {
+    pub fn new(app_version: impl Into<String>, app_type: AppType) -> Self {
+        Self {
+            app_version: app_version.into(),
+            app_type,
+        }
+    }
+
+    /// The wire-protocol version baked into this crate — kept in sync with
+    /// `@thaumic-cast/protocol`'s exported `PROTOCOL_VERSION`.
+    pub fn protocol_version(&self) -> &'static str {
+        PROTOCOL_VERSION
+    }
+}
 
 /// Errors that can occur when starting or running the server.
 #[derive(Debug, Error)]
@@ -78,6 +118,8 @@ pub struct AppState {
     /// Optional factory for creating browser capture sources (Windows only).
     /// Set by the desktop app; `None` on the headless server.
     pub capture_factory: Option<Arc<dyn CaptureSourceFactory>>,
+    /// Version metadata advertised to the extension on handshake.
+    pub app_info: AppInfo,
 }
 
 impl AppState {
@@ -91,6 +133,7 @@ impl AppState {
         services: &crate::BootstrappedServices,
         config: Arc<RwLock<Config>>,
         artwork_config: ArtworkConfig,
+        app_info: AppInfo,
     ) -> Self {
         Self {
             sonos: Arc::clone(&services.sonos),
@@ -106,6 +149,7 @@ impl AppState {
             artwork: artwork_config.resolve(),
             mdns_advertiser: Arc::new(RwLock::new(None)),
             capture_factory: None,
+            app_info,
         }
     }
 

--- a/packages/thaumic-core/src/api/ws.rs
+++ b/packages/thaumic-core/src/api/ws.rs
@@ -297,10 +297,16 @@ impl WsOutgoing {
 }
 
 /// Handshake acknowledgment payload.
+///
+/// Extension clients parse `protocolVersion`, `appVersion`, and `appType` to
+/// surface version-mismatch warnings and populate their About surfaces.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct HandshakePayload {
     stream_id: String,
+    protocol_version: &'static str,
+    app_version: String,
+    app_type: crate::api::AppType,
 }
 
 /// Sends a response based on an already-resolved result.
@@ -683,6 +689,9 @@ async fn handle_start_browser_capture(
             let ack = WsOutgoing::HandshakeAck {
                 payload: HandshakePayload {
                     stream_id: stream_id.clone(),
+                    protocol_version: state.app_info.protocol_version(),
+                    app_version: state.app_info.app_version.clone(),
+                    app_type: state.app_info.app_type,
                 },
             };
             if let Some(msg) = ack.to_message() {
@@ -901,7 +910,12 @@ async fn handle_ws(socket: WebSocket, state: AppState) {
                                             Arc::clone(&state.stream_coordinator),
                                         );
                                         let ack = WsOutgoing::HandshakeAck {
-                                            payload: HandshakePayload { stream_id: id },
+                                            payload: HandshakePayload {
+                                                stream_id: id,
+                                                protocol_version: state.app_info.protocol_version(),
+                                                app_version: state.app_info.app_version.clone(),
+                                                app_type: state.app_info.app_type,
+                                            },
                                         };
                                         stream_guard = Some(guard);
                                         if let Some(msg) = ack.to_message() {

--- a/packages/thaumic-core/src/api/ws.rs
+++ b/packages/thaumic-core/src/api/ws.rs
@@ -298,29 +298,14 @@ impl WsOutgoing {
 
 /// Handshake acknowledgment payload.
 ///
-/// Extension clients parse `protocolVersion`, `appVersion`, and `appType` to
-/// surface version-mismatch warnings and populate their About surfaces.
+/// Carries the assigned `stream_id` only. Companion version metadata
+/// (`protocolVersion`, `appVersion`, `appType`) is reported via
+/// `INITIAL_STATE`, which fires on every WS connect — so the extension's
+/// always-on control connection sees it without waiting for a stream.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct HandshakePayload {
     stream_id: String,
-    protocol_version: &'static str,
-    app_version: &'static str,
-    app_type: crate::api::AppType,
-}
-
-impl HandshakePayload {
-    /// Builds a payload for `stream_id`, filling the version fields from `state`.
-    ///
-    /// Single construction site so additions to the ACK only need one edit.
-    fn from_state(stream_id: String, state: &AppState) -> Self {
-        Self {
-            stream_id,
-            protocol_version: crate::protocol_constants::PROTOCOL_VERSION,
-            app_version: state.app_info.app_version,
-            app_type: state.app_info.app_type,
-        }
-    }
 }
 
 /// Sends a response based on an already-resolved result.
@@ -372,8 +357,14 @@ async fn send_command_response<F, T, E, R>(
 
 /// Builds the initial state message for WebSocket clients.
 ///
-/// Includes Sonos state (groups, transport, volume, mute), active playback sessions,
-/// and current network health status.
+/// Includes Sonos state (groups, transport, volume, mute), active playback
+/// sessions, current network health status, and the companion's version
+/// metadata (`appVersion`, `protocolVersion`, `appType`).
+///
+/// `INITIAL_STATE` fires on every WebSocket connect — including the always-on
+/// control connection the extension uses purely for state monitoring — so
+/// putting the version fields here means the extension's mismatch warning
+/// fires immediately, without waiting for the user to start a stream.
 fn build_initial_state(state: &AppState) -> Option<Message> {
     let mut payload = state.sonos_state.to_json();
 
@@ -407,6 +398,21 @@ fn build_initial_state(state: &AppState) -> Option<Message> {
                 "networkHealthReason".to_string(),
                 serde_json::Value::String(reason.clone()),
             );
+        }
+
+        // Companion version metadata — same fields as HANDSHAKE_ACK so the
+        // extension's control connection can drive the version-mismatch
+        // warning without waiting for the user to start a stream.
+        map.insert(
+            "protocolVersion".to_string(),
+            serde_json::Value::String(crate::protocol_constants::PROTOCOL_VERSION.to_string()),
+        );
+        map.insert(
+            "appVersion".to_string(),
+            serde_json::Value::String(state.app_info.app_version.to_string()),
+        );
+        if let Ok(app_type_json) = serde_json::to_value(state.app_info.app_type) {
+            map.insert("appType".to_string(), app_type_json);
         }
     }
 
@@ -701,7 +707,9 @@ async fn handle_start_browser_capture(
 
             // Send handshake ack with the stream ID
             let ack = WsOutgoing::HandshakeAck {
-                payload: HandshakePayload::from_state(stream_id.clone(), state),
+                payload: HandshakePayload {
+                    stream_id: stream_id.clone(),
+                },
             };
             if let Some(msg) = ack.to_message() {
                 let _ = sender.send(msg).await;
@@ -919,7 +927,7 @@ async fn handle_ws(socket: WebSocket, state: AppState) {
                                             Arc::clone(&state.stream_coordinator),
                                         );
                                         let ack = WsOutgoing::HandshakeAck {
-                                            payload: HandshakePayload::from_state(id, &state),
+                                            payload: HandshakePayload { stream_id: id },
                                         };
                                         stream_guard = Some(guard);
                                         if let Some(msg) = ack.to_message() {

--- a/packages/thaumic-core/src/api/ws.rs
+++ b/packages/thaumic-core/src/api/ws.rs
@@ -305,8 +305,22 @@ impl WsOutgoing {
 struct HandshakePayload {
     stream_id: String,
     protocol_version: &'static str,
-    app_version: String,
+    app_version: &'static str,
     app_type: crate::api::AppType,
+}
+
+impl HandshakePayload {
+    /// Builds a payload for `stream_id`, filling the version fields from `state`.
+    ///
+    /// Single construction site so additions to the ACK only need one edit.
+    fn from_state(stream_id: String, state: &AppState) -> Self {
+        Self {
+            stream_id,
+            protocol_version: crate::protocol_constants::PROTOCOL_VERSION,
+            app_version: state.app_info.app_version,
+            app_type: state.app_info.app_type,
+        }
+    }
 }
 
 /// Sends a response based on an already-resolved result.
@@ -687,12 +701,7 @@ async fn handle_start_browser_capture(
 
             // Send handshake ack with the stream ID
             let ack = WsOutgoing::HandshakeAck {
-                payload: HandshakePayload {
-                    stream_id: stream_id.clone(),
-                    protocol_version: state.app_info.protocol_version(),
-                    app_version: state.app_info.app_version.clone(),
-                    app_type: state.app_info.app_type,
-                },
+                payload: HandshakePayload::from_state(stream_id.clone(), state),
             };
             if let Some(msg) = ack.to_message() {
                 let _ = sender.send(msg).await;
@@ -910,12 +919,7 @@ async fn handle_ws(socket: WebSocket, state: AppState) {
                                             Arc::clone(&state.stream_coordinator),
                                         );
                                         let ack = WsOutgoing::HandshakeAck {
-                                            payload: HandshakePayload {
-                                                stream_id: id,
-                                                protocol_version: state.app_info.protocol_version(),
-                                                app_version: state.app_info.app_version.clone(),
-                                                app_type: state.app_info.app_type,
-                                            },
+                                            payload: HandshakePayload::from_state(id, &state),
                                         };
                                         stream_guard = Some(guard);
                                         if let Some(msg) = ack.to_message() {

--- a/packages/thaumic-core/src/lib.rs
+++ b/packages/thaumic-core/src/lib.rs
@@ -83,7 +83,7 @@ pub use bootstrap::{bootstrap_services, bootstrap_services_with_network, Bootstr
 pub use streaming_runtime::StreamingRuntime;
 
 // Re-export API types
-pub use api::{start_server, AppState, ServerError, WsConnectionManager};
+pub use api::{start_server, AppInfo, AppState, AppType, ServerError, WsConnectionManager};
 
 /// Default artwork for Sonos album art display.
 ///

--- a/packages/thaumic-core/src/protocol_constants.rs
+++ b/packages/thaumic-core/src/protocol_constants.rs
@@ -73,11 +73,11 @@ pub const APP_NAME: &str = "Thaumic Cast";
 
 /// Wire-protocol semver advertised to extension clients in the handshake ACK.
 ///
-/// Must stay in sync with the `PROTOCOL_VERSION` constant exported from
-/// `@thaumic-cast/protocol` (`packages/protocol/src/websocket.ts`).
-///
-/// Bump on any wire-schema change. For breaking changes, bump the extension's
-/// `MIN_COMPATIBLE_PROTOCOL_VERSION` in the same PR.
+/// Kept in sync with `@thaumic-cast/protocol`'s exported `PROTOCOL_VERSION`
+/// (`packages/protocol/src/websocket.ts`) by `scripts/sync-versions.ts`,
+/// invoked at release time via `bun run changeset:version`. Do not edit by
+/// hand; see `CONTRIBUTING.md` → Protocol versioning for the bump policy and
+/// its relationship with `MIN_COMPATIBLE_PROTOCOL_VERSION`.
 pub const PROTOCOL_VERSION: &str = "0.4.0";
 
 /// Service identifier used for discovery (health endpoint).

--- a/packages/thaumic-core/src/protocol_constants.rs
+++ b/packages/thaumic-core/src/protocol_constants.rs
@@ -71,6 +71,15 @@ pub const MAX_GENA_BODY_SIZE: usize = 64 * 1024;
 /// where consistency matters more than translation.
 pub const APP_NAME: &str = "Thaumic Cast";
 
+/// Wire-protocol semver advertised to extension clients in the handshake ACK.
+///
+/// Must stay in sync with the `PROTOCOL_VERSION` constant exported from
+/// `@thaumic-cast/protocol` (`packages/protocol/src/websocket.ts`).
+///
+/// Bump on any wire-schema change. For breaking changes, bump the extension's
+/// `MIN_COMPATIBLE_PROTOCOL_VERSION` in the same PR.
+pub const PROTOCOL_VERSION: &str = "0.4.0";
+
 /// Service identifier used for discovery (health endpoint).
 ///
 /// The extension probes /health and expects this exact string to identify

--- a/packages/ui/src/Button/Button.module.css
+++ b/packages/ui/src/Button/Button.module.css
@@ -58,3 +58,24 @@
 .danger:not(:disabled):hover {
   background-color: var(--button-danger-bg-hover);
 }
+
+/* Inline text-link variant — for calls to action that sit alongside body
+ * text. Strips the box styling so it reads as a hyperlink. The base .btn
+ * uses flex with gap; we override to inline so the link sits with adjacent
+ * text without breaking onto its own line. */
+.link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-link);
+  text-decoration: underline;
+  cursor: pointer;
+  display: inline;
+  inline-size: auto;
+}
+
+.link:not(:disabled):hover {
+  color: var(--color-link-hover);
+  text-decoration: none;
+}

--- a/packages/ui/src/Button/Button.tsx
+++ b/packages/ui/src/Button/Button.tsx
@@ -2,8 +2,13 @@ import { h } from 'preact';
 import styles from './Button.module.css';
 
 interface ButtonProps extends h.JSX.HTMLAttributes<HTMLButtonElement> {
-  /** Button style variant */
-  variant?: 'primary' | 'secondary' | 'danger';
+  /**
+   * Button style variant.
+   * - `primary`/`secondary`/`danger`: standard solid buttons.
+   * - `link`: borderless, padding-less, underlined text — for inline calls
+   *   to action that should sit alongside other text without dominating it.
+   */
+  variant?: 'primary' | 'secondary' | 'danger' | 'link';
   /** Whether the button is disabled */
   disabled?: boolean;
   /** Whether the button should take full width of its container */
@@ -32,7 +37,9 @@ export function Button({
       ? styles.primary
       : variant === 'secondary'
         ? styles.secondary
-        : styles.danger;
+        : variant === 'link'
+          ? styles.link
+          : styles.danger;
   const widthClass = fullWidth ? styles.fullWidth : '';
   const combinedClass = [styles.btn, variantClass, widthClass, className].filter(Boolean).join(' ');
 

--- a/scripts/sync-versions.ts
+++ b/scripts/sync-versions.ts
@@ -16,6 +16,19 @@ import { join } from 'node:path';
 /** Regex to match version in Cargo.toml [package] section. */
 const CARGO_VERSION_REGEX = /^(version\s*=\s*")([^"]+)(")/m;
 
+/**
+ * Regex to match the `PROTOCOL_VERSION` constant exported from
+ * `@thaumic-cast/protocol`. Quote-agnostic: accepts either single or double
+ * quotes so the match keeps working if Prettier config flips quote style. The
+ * second capture group is the opening quote, which we reuse on replace to
+ * preserve the file's existing style.
+ */
+const TS_PROTOCOL_VERSION_REGEX =
+  /^(export const PROTOCOL_VERSION = )(['"])([^'"]+)\2( as const;)/m;
+
+/** Regex to match the `PROTOCOL_VERSION` constant in `thaumic-core`'s `protocol_constants.rs`. */
+const RUST_PROTOCOL_VERSION_REGEX = /^(pub const PROTOCOL_VERSION: &str = ")([^"]+)(";)/m;
+
 const ROOT = join(import.meta.dirname, '..');
 
 /** Minimal package.json structure for version extraction. */
@@ -90,7 +103,10 @@ function syncDesktopVersion(): void {
       console.log(`desktop (Cargo.toml): ${pkg.version} (no change)`);
     }
   } else {
-    console.warn('desktop (Cargo.toml): version not found');
+    throw new Error(
+      'desktop (Cargo.toml): [package] version declaration not found. ' +
+        'If the declaration syntax changed, update CARGO_VERSION_REGEX in scripts/sync-versions.ts.',
+    );
   }
 }
 
@@ -135,7 +151,10 @@ function syncCoreVersion(): void {
       console.log(`thaumic-core (Cargo.toml): ${pkg.version} (no change)`);
     }
   } else {
-    console.warn('thaumic-core (Cargo.toml): version not found');
+    throw new Error(
+      'thaumic-core (Cargo.toml): [package] version declaration not found. ' +
+        'If the declaration syntax changed, update CARGO_VERSION_REGEX in scripts/sync-versions.ts.',
+    );
   }
 }
 
@@ -161,7 +180,72 @@ function syncServerVersion(): void {
       console.log(`server (Cargo.toml): ${pkg.version} (no change)`);
     }
   } else {
-    console.warn('server (Cargo.toml): version not found');
+    throw new Error(
+      'server (Cargo.toml): [package] version declaration not found. ' +
+        'If the declaration syntax changed, update CARGO_VERSION_REGEX in scripts/sync-versions.ts.',
+    );
+  }
+}
+
+/**
+ * Syncs the wire-protocol version from `packages/protocol/package.json` to the
+ * two places it is hard-coded:
+ *
+ * - `packages/protocol/src/websocket.ts` — `PROTOCOL_VERSION` constant the
+ *   extension embeds in its `About` surface and `MIN_COMPATIBLE_PROTOCOL_VERSION`
+ *   comparison.
+ * - `packages/thaumic-core/src/protocol_constants.rs` — `PROTOCOL_VERSION`
+ *   the companion emits in the WebSocket handshake ACK.
+ *
+ * Rust and TS must report the same value; drift would cause the out-of-date
+ * warning to either miss a real mismatch or misfire against a matching build.
+ * See `CONTRIBUTING.md` → Protocol versioning.
+ */
+function syncProtocolVersion(): void {
+  const pkgPath = join(ROOT, 'packages/protocol/package.json');
+  const tsPath = join(ROOT, 'packages/protocol/src/websocket.ts');
+  const rustPath = join(ROOT, 'packages/thaumic-core/src/protocol_constants.rs');
+
+  const pkg = readJson<PackageJson>(pkgPath);
+  const target = pkg.version;
+
+  // Sync TS constant. Capture groups for TS_PROTOCOL_VERSION_REGEX:
+  //   $1 = `export const PROTOCOL_VERSION = `, $2 = opening quote (' or "),
+  //   $3 = current version, $4 = ` as const;`
+  const tsContent = readFileSync(tsPath, 'utf-8');
+  const tsMatch = tsContent.match(TS_PROTOCOL_VERSION_REGEX);
+  if (!tsMatch) {
+    // Release-path failure: refuse to continue rather than ship stale constants.
+    throw new Error(
+      `protocol (websocket.ts): PROTOCOL_VERSION declaration not found. ` +
+        `If the declaration syntax changed, update TS_PROTOCOL_VERSION_REGEX.`,
+    );
+  }
+  const tsCurrent = tsMatch[3];
+  if (tsCurrent !== target) {
+    console.log(`protocol (websocket.ts): ${tsCurrent} -> ${target}`);
+    const updated = tsContent.replace(TS_PROTOCOL_VERSION_REGEX, `$1$2${target}$2$4`);
+    writeFileSync(tsPath, updated);
+  } else {
+    console.log(`protocol (websocket.ts): ${target} (no change)`);
+  }
+
+  // Sync Rust constant
+  const rustContent = readFileSync(rustPath, 'utf-8');
+  const rustMatch = rustContent.match(RUST_PROTOCOL_VERSION_REGEX);
+  if (!rustMatch) {
+    throw new Error(
+      `protocol (protocol_constants.rs): PROTOCOL_VERSION declaration not found. ` +
+        `If the declaration syntax changed, update RUST_PROTOCOL_VERSION_REGEX.`,
+    );
+  }
+  const rustCurrent = rustMatch[2];
+  if (rustCurrent !== target) {
+    console.log(`protocol (protocol_constants.rs): ${rustCurrent} -> ${target}`);
+    const updated = rustContent.replace(RUST_PROTOCOL_VERSION_REGEX, `$1${target}$3`);
+    writeFileSync(rustPath, updated);
+  } else {
+    console.log(`protocol (protocol_constants.rs): ${target} (no change)`);
   }
 }
 
@@ -171,4 +255,5 @@ syncDesktopVersion();
 syncExtensionVersion();
 syncServerVersion();
 syncCoreVersion();
+syncProtocolVersion();
 console.log('Done.');

--- a/scripts/sync-versions.ts
+++ b/scripts/sync-versions.ts
@@ -1,11 +1,19 @@
 /**
- * Syncs version numbers from package.json to native config files.
+ * Syncs version numbers from each app/package's `package.json` into the other
+ * places the same version is declared. Invoked at release time by
+ * `bun run changeset:version` so released artifacts always agree on version.
  *
- * This script ensures that version numbers stay consistent across:
- * - Desktop: package.json -> tauri.conf.json, Cargo.toml
- * - Extension: package.json -> manifest.json
- * - Server: package.json -> Cargo.toml
- * - Core: package.json -> Cargo.toml
+ * Syncs performed:
+ * - Desktop: `package.json` → `tauri.conf.json`, `Cargo.toml`
+ * - Extension: `package.json` → `manifest.json`
+ * - Server: `package.json` → `Cargo.toml`
+ * - Core: `package.json` → `Cargo.toml`
+ * - Protocol: `package.json` → `websocket.ts`, `protocol_constants.rs`
+ *
+ * Failure policy: if any regex-based sync can't locate the target declaration
+ * (e.g. the syntax was refactored without updating the regex here), the script
+ * throws rather than warning-and-continuing. The release pipeline will fail
+ * loudly rather than ship drifted versions silently.
  *
  * @module sync-versions
  */
@@ -13,20 +21,19 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-/** Regex to match version in Cargo.toml [package] section. */
+/** Matches the `version = "…"` declaration in a Cargo.toml `[package]` section. */
 const CARGO_VERSION_REGEX = /^(version\s*=\s*")([^"]+)(")/m;
 
 /**
- * Regex to match the `PROTOCOL_VERSION` constant exported from
- * `@thaumic-cast/protocol`. Quote-agnostic: accepts either single or double
- * quotes so the match keeps working if Prettier config flips quote style. The
- * second capture group is the opening quote, which we reuse on replace to
- * preserve the file's existing style.
+ * Matches the `PROTOCOL_VERSION` constant exported from `@thaumic-cast/protocol`.
+ * Quote-agnostic: accepts either single or double quotes so the match keeps
+ * working if Prettier config flips quote style. The second capture group is
+ * the opening quote, which is reused on replace (via `$2`) to preserve style.
  */
 const TS_PROTOCOL_VERSION_REGEX =
   /^(export const PROTOCOL_VERSION = )(['"])([^'"]+)\2( as const;)/m;
 
-/** Regex to match the `PROTOCOL_VERSION` constant in `thaumic-core`'s `protocol_constants.rs`. */
+/** Matches the `PROTOCOL_VERSION` constant in `thaumic-core`'s `protocol_constants.rs`. */
 const RUST_PROTOCOL_VERSION_REGEX = /^(pub const PROTOCOL_VERSION: &str = ")([^"]+)(";)/m;
 
 const ROOT = join(import.meta.dirname, '..');
@@ -70,8 +77,66 @@ function writeJson(filePath: string, data: unknown): void {
 }
 
 /**
- * Syncs the desktop app version from package.json to tauri.conf.json and Cargo.toml.
- * Logs the version change or indicates no change was needed.
+ * Syncs a single `target` version into `filePath` by matching `regex` and
+ * rewriting with `replaceTemplate`. Throws if the regex does not match, so
+ * release-time callers can fail fast rather than ship drifted versions.
+ *
+ * @param options - File/regex/label configuration for this sync
+ * @param options.filePath - Absolute path to the file to update
+ * @param options.regex - Regex that matches the version declaration
+ * @param options.versionGroup - 1-indexed capture group that holds the current version
+ * @param options.replaceTemplate - `String.replace` template used with `regex`
+ *   (e.g. `'$1<new>$3'`). Interpolate the target version into this string.
+ * @param options.target - Desired version (drives `replaceTemplate`)
+ * @param options.label - Human-readable label for logs and error messages
+ */
+function syncRegexFile(options: {
+  filePath: string;
+  regex: RegExp;
+  versionGroup: number;
+  replaceTemplate: string;
+  target: string;
+  label: string;
+}): void {
+  const { filePath, regex, versionGroup, replaceTemplate, target, label } = options;
+  const content = readFileSync(filePath, 'utf-8');
+  const match = content.match(regex);
+  if (!match) {
+    throw new Error(
+      `${label}: version declaration not found. ` +
+        `If the declaration syntax changed, update the matching regex in scripts/sync-versions.ts.`,
+    );
+  }
+  const current = match[versionGroup];
+  if (current !== target) {
+    console.log(`${label}: ${current} -> ${target}`);
+    writeFileSync(filePath, content.replace(regex, replaceTemplate));
+  } else {
+    console.log(`${label}: ${target} (no change)`);
+  }
+}
+
+/**
+ * Cargo-specific convenience wrapper around `syncRegexFile`.
+ *
+ * @param filePath - Absolute path to the `Cargo.toml` to update
+ * @param target - Version string to write into the `[package].version` field
+ * @param label - Human-readable label for logs and error messages
+ */
+function syncCargoVersion(filePath: string, target: string, label: string): void {
+  syncRegexFile({
+    filePath,
+    regex: CARGO_VERSION_REGEX,
+    versionGroup: 2,
+    replaceTemplate: `$1${target}$3`,
+    target,
+    label,
+  });
+}
+
+/**
+ * Syncs the desktop app version from `package.json` to `tauri.conf.json`
+ * and `Cargo.toml`.
  */
 function syncDesktopVersion(): void {
   const pkgPath = join(ROOT, 'apps/desktop/package.json');
@@ -81,7 +146,6 @@ function syncDesktopVersion(): void {
   const pkg = readJson<PackageJson>(pkgPath);
   const tauri = readJson<TauriConfig>(tauriPath);
 
-  // Sync tauri.conf.json
   if (tauri.version !== pkg.version) {
     console.log(`desktop (tauri.conf.json): ${tauri.version} -> ${pkg.version}`);
     tauri.version = pkg.version;
@@ -90,30 +154,10 @@ function syncDesktopVersion(): void {
     console.log(`desktop (tauri.conf.json): ${pkg.version} (no change)`);
   }
 
-  // Sync Cargo.toml
-  const cargoContent = readFileSync(cargoPath, 'utf-8');
-  const cargoMatch = cargoContent.match(CARGO_VERSION_REGEX);
-  if (cargoMatch) {
-    const currentVersion = cargoMatch[2];
-    if (currentVersion !== pkg.version) {
-      console.log(`desktop (Cargo.toml): ${currentVersion} -> ${pkg.version}`);
-      const updatedCargo = cargoContent.replace(CARGO_VERSION_REGEX, `$1${pkg.version}$3`);
-      writeFileSync(cargoPath, updatedCargo);
-    } else {
-      console.log(`desktop (Cargo.toml): ${pkg.version} (no change)`);
-    }
-  } else {
-    throw new Error(
-      'desktop (Cargo.toml): [package] version declaration not found. ' +
-        'If the declaration syntax changed, update CARGO_VERSION_REGEX in scripts/sync-versions.ts.',
-    );
-  }
+  syncCargoVersion(cargoPath, pkg.version, 'desktop (Cargo.toml)');
 }
 
-/**
- * Syncs the extension version from package.json to manifest.json.
- * Logs the version change or indicates no change was needed.
- */
+/** Syncs the extension version from `package.json` to `manifest.json`. */
 function syncExtensionVersion(): void {
   const pkgPath = join(ROOT, 'apps/extension/package.json');
   const manifestPath = join(ROOT, 'apps/extension/manifest.json');
@@ -130,61 +174,20 @@ function syncExtensionVersion(): void {
   }
 }
 
-/**
- * Syncs the thaumic-core version from package.json to Cargo.toml.
- */
+/** Syncs the thaumic-core version from `package.json` to `Cargo.toml`. */
 function syncCoreVersion(): void {
-  const pkgPath = join(ROOT, 'packages/thaumic-core/package.json');
-  const cargoPath = join(ROOT, 'packages/thaumic-core/Cargo.toml');
-
-  const pkg = readJson<PackageJson>(pkgPath);
-  const cargoContent = readFileSync(cargoPath, 'utf-8');
-  const cargoMatch = cargoContent.match(CARGO_VERSION_REGEX);
-
-  if (cargoMatch) {
-    const currentVersion = cargoMatch[2];
-    if (currentVersion !== pkg.version) {
-      console.log(`thaumic-core (Cargo.toml): ${currentVersion} -> ${pkg.version}`);
-      const updatedCargo = cargoContent.replace(CARGO_VERSION_REGEX, `$1${pkg.version}$3`);
-      writeFileSync(cargoPath, updatedCargo);
-    } else {
-      console.log(`thaumic-core (Cargo.toml): ${pkg.version} (no change)`);
-    }
-  } else {
-    throw new Error(
-      'thaumic-core (Cargo.toml): [package] version declaration not found. ' +
-        'If the declaration syntax changed, update CARGO_VERSION_REGEX in scripts/sync-versions.ts.',
-    );
-  }
+  const pkg = readJson<PackageJson>(join(ROOT, 'packages/thaumic-core/package.json'));
+  syncCargoVersion(
+    join(ROOT, 'packages/thaumic-core/Cargo.toml'),
+    pkg.version,
+    'thaumic-core (Cargo.toml)',
+  );
 }
 
-/**
- * Syncs the server version from package.json to Cargo.toml.
- * This ensures the server binary version stays in sync with the product version.
- */
+/** Syncs the headless-server version from `package.json` to `Cargo.toml`. */
 function syncServerVersion(): void {
-  const pkgPath = join(ROOT, 'apps/server/package.json');
-  const cargoPath = join(ROOT, 'apps/server/Cargo.toml');
-
-  const pkg = readJson<PackageJson>(pkgPath);
-  const cargoContent = readFileSync(cargoPath, 'utf-8');
-  const cargoMatch = cargoContent.match(CARGO_VERSION_REGEX);
-
-  if (cargoMatch) {
-    const currentVersion = cargoMatch[2];
-    if (currentVersion !== pkg.version) {
-      console.log(`server (Cargo.toml): ${currentVersion} -> ${pkg.version}`);
-      const updatedCargo = cargoContent.replace(CARGO_VERSION_REGEX, `$1${pkg.version}$3`);
-      writeFileSync(cargoPath, updatedCargo);
-    } else {
-      console.log(`server (Cargo.toml): ${pkg.version} (no change)`);
-    }
-  } else {
-    throw new Error(
-      'server (Cargo.toml): [package] version declaration not found. ' +
-        'If the declaration syntax changed, update CARGO_VERSION_REGEX in scripts/sync-versions.ts.',
-    );
-  }
+  const pkg = readJson<PackageJson>(join(ROOT, 'apps/server/package.json'));
+  syncCargoVersion(join(ROOT, 'apps/server/Cargo.toml'), pkg.version, 'server (Cargo.toml)');
 }
 
 /**
@@ -202,58 +205,42 @@ function syncServerVersion(): void {
  * See `CONTRIBUTING.md` → Protocol versioning.
  */
 function syncProtocolVersion(): void {
-  const pkgPath = join(ROOT, 'packages/protocol/package.json');
-  const tsPath = join(ROOT, 'packages/protocol/src/websocket.ts');
-  const rustPath = join(ROOT, 'packages/thaumic-core/src/protocol_constants.rs');
-
-  const pkg = readJson<PackageJson>(pkgPath);
+  const pkg = readJson<PackageJson>(join(ROOT, 'packages/protocol/package.json'));
   const target = pkg.version;
 
-  // Sync TS constant. Capture groups for TS_PROTOCOL_VERSION_REGEX:
-  //   $1 = `export const PROTOCOL_VERSION = `, $2 = opening quote (' or "),
-  //   $3 = current version, $4 = ` as const;`
-  const tsContent = readFileSync(tsPath, 'utf-8');
-  const tsMatch = tsContent.match(TS_PROTOCOL_VERSION_REGEX);
-  if (!tsMatch) {
-    // Release-path failure: refuse to continue rather than ship stale constants.
-    throw new Error(
-      `protocol (websocket.ts): PROTOCOL_VERSION declaration not found. ` +
-        `If the declaration syntax changed, update TS_PROTOCOL_VERSION_REGEX.`,
-    );
-  }
-  const tsCurrent = tsMatch[3];
-  if (tsCurrent !== target) {
-    console.log(`protocol (websocket.ts): ${tsCurrent} -> ${target}`);
-    const updated = tsContent.replace(TS_PROTOCOL_VERSION_REGEX, `$1$2${target}$2$4`);
-    writeFileSync(tsPath, updated);
-  } else {
-    console.log(`protocol (websocket.ts): ${target} (no change)`);
-  }
+  // TS regex capture groups: $1 = prefix, $2 = opening quote, $3 = version,
+  // $4 = suffix. Replace reuses $2 for both quotes to preserve the file's
+  // existing style (single or double).
+  syncRegexFile({
+    filePath: join(ROOT, 'packages/protocol/src/websocket.ts'),
+    regex: TS_PROTOCOL_VERSION_REGEX,
+    versionGroup: 3,
+    replaceTemplate: `$1$2${target}$2$4`,
+    target,
+    label: 'protocol (websocket.ts)',
+  });
 
-  // Sync Rust constant
-  const rustContent = readFileSync(rustPath, 'utf-8');
-  const rustMatch = rustContent.match(RUST_PROTOCOL_VERSION_REGEX);
-  if (!rustMatch) {
-    throw new Error(
-      `protocol (protocol_constants.rs): PROTOCOL_VERSION declaration not found. ` +
-        `If the declaration syntax changed, update RUST_PROTOCOL_VERSION_REGEX.`,
-    );
-  }
-  const rustCurrent = rustMatch[2];
-  if (rustCurrent !== target) {
-    console.log(`protocol (protocol_constants.rs): ${rustCurrent} -> ${target}`);
-    const updated = rustContent.replace(RUST_PROTOCOL_VERSION_REGEX, `$1${target}$3`);
-    writeFileSync(rustPath, updated);
-  } else {
-    console.log(`protocol (protocol_constants.rs): ${target} (no change)`);
-  }
+  syncRegexFile({
+    filePath: join(ROOT, 'packages/thaumic-core/src/protocol_constants.rs'),
+    regex: RUST_PROTOCOL_VERSION_REGEX,
+    versionGroup: 2,
+    replaceTemplate: `$1${target}$3`,
+    target,
+    label: 'protocol (protocol_constants.rs)',
+  });
 }
 
-// Main execution
-console.log('Syncing versions...');
-syncDesktopVersion();
-syncExtensionVersion();
-syncServerVersion();
-syncCoreVersion();
-syncProtocolVersion();
-console.log('Done.');
+// Main execution — wrap in try/catch so CI output is one clean error line
+// instead of a stack trace, while still exiting non-zero.
+try {
+  console.log('Syncing versions...');
+  syncDesktopVersion();
+  syncExtensionVersion();
+  syncServerVersion();
+  syncCoreVersion();
+  syncProtocolVersion();
+  console.log('Done.');
+} catch (err) {
+  console.error(`sync-versions failed: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## What

When the Chrome extension is auto-updated to a newer protocol version than the user's desktop app or server, the popup now visibly tells them — with a route to the GitHub releases page — instead of silently breaking playback.

Companion identity (`appType` / `appVersion` / `protocolVersion`) flows through the connection paths the extension already uses:

- `/health` reports `appType` so discovery knows the companion type before the WebSocket connects.
- `INITIAL_STATE` (sent on every WebSocket connect, including the always-on control connection) carries `appVersion` and `protocolVersion`. This is what makes the warning fire even for users who never start a stream.
- All three fields land on `connectionState` — there's no separate companion-info storage. The popup, options About card, and version-check helpers all read from the same place.
- `HANDSHAKE_ACK` does **not** carry version metadata; the streaming handshake is back to just `{ stream_id }`.

### UI surfaces

- **Popup Alert** — dismissible warning with an action button ("Update Desktop App" / "Update Server" / "Update") deep-linking to GitHub releases. Dismissal is keyed by `appVersion` bucket — `null` is its own bucket for pre-0.4.0 companions, so dismissing for "unknown" doesn't leak forward to a real version.
- **Popup footer** — type-aware status ("Connected to Desktop App" / "Connected to Server" / "Connected" when type is unknown). Persistent inline "Update available" link appears alongside the status whenever there's a mismatch, even after the Alert is dismissed.
- **Options About card** — companion type, version, protocol; for known-but-outdated or unknown-version companions, an inline "· Update available" sits next to the version line.

Pre-0.4.0 companions trigger the warning rather than being treated as "assume compatible" — Chrome may auto-update the extension ahead of the user updating their companion, and we shouldn't silently bypass the warning in that gap. Copy degrades gracefully ("Your app predates this extension and can't report its version").

### Supporting changes

- `thaumic-core` exposes `AppInfo` / `AppType` passed to `AppState::new`; `apps/desktop` and `apps/server` thread their own `env!("CARGO_PKG_VERSION")` through.
- `@thaumic-cast/shared` gains `GITHUB_RELEASES_URL` + `MIN_COMPATIBLE_PROTOCOL_VERSION`; two hardcoded URL occurrences deduped.
- `@thaumic-cast/ui` gains a `link` variant on `<Button>` (borderless, padding-less, underlined inline text), used by both the popup footer and the About card.
- `scripts/sync-versions.ts` propagates `@thaumic-cast/protocol`'s version into both the TS and Rust `PROTOCOL_VERSION` constants, with a quote-agnostic regex and hard failure on declaration-syntax drift.
- `CONTRIBUTING.md` documents the three-way sync, the `fixed` changeset group, and the `MIN_COMPATIBLE_PROTOCOL_VERSION` bump policy.

### Forward-compat

- `INITIAL_STATE` and `/health` both treat the new fields as optional and degrade unknown values to `undefined`/`null`, so a future companion variant (e.g. `appType: "cli"`) can't kill the connect path on an older extension.

### Bug fixes uncovered while building this

- The original implementation persisted companion info from `worker-base.ts` (audio worker) and a short-lived `COMPANION_INFO_UPDATE` route in the offscreen using `chrome.storage.local.set` — which never worked, since `chrome.storage` isn't available in offscreen documents or Web Workers. All persistence now happens in the background service worker, which has full storage access. Symptom on `main` would have been: the About surface always saying "No companion currently connected".

## Why

The Chrome extension auto-updates via the Web Store, but the desktop app and standalone server do not. When the extension ships a protocol-affecting change, users on an older companion silently hit broken playback with no signal pointing at the cause. This adds a soft, privacy-preserving warning — no new remote calls; everything runs off the existing `/health` probe and WebSocket — that routes users to the GitHub releases page.

We deliberately picked *soft warn* over hard block (per earlier discussion) and deferred `tauri-plugin-updater` to a potential follow-up: it needs code-signing infra, introduces a remote call from the desktop app, and does nothing for the headless server.

## How to Test

### Compatible path
1. Build extension + desktop (or run the server) at matching versions.
2. Connect and verify:
   - No warning Alert in the popup.
   - Footer reads "Connected to Desktop App" (or "Connected to Server").
   - Extension Options → About shows companion type, version, and protocol version.

### Mismatch path (simulate out-of-date companion)
1. Temporarily raise `MIN_COMPATIBLE_PROTOCOL_VERSION` in `packages/shared/src/constants.ts` above what the companion reports (e.g. `'0.99.0'`).
2. Reload the extension and reconnect.
3. Expect a warning Alert in the popup with action button "Update Desktop App" (or "Update Server"). Footer reads "Connected to … · Update available".
4. Click the action button → releases page opens in a new tab.
5. Dismiss the Alert → it disappears; footer "Update available" link remains; close and reopen the popup → Alert stays dismissed, footer link still visible.
6. Manually bump the companion's `appVersion` string and reconnect → Alert re-appears (dismissal keyed on the old version).
7. Open Options → About shows "<type> · vX.Y.Z · Update available" inline.

### Pre-0.4.0 / unknown-companion path
1. Easiest simulation: in `apps/extension/src/offscreen/control-connection.ts`, force `appVersion`/`protocolVersion` to `null` when sending `WS_CONNECTED`.
2. Reconnect. Expect:
   - Popup Alert: "Your app predates this extension and can't report its version. Update to restore harmony." with a single "Update" action button.
   - Footer: "Connected · Update available".
   - About card: "Unknown version · Update available" inline.
3. Dismiss → Alert disappears; reopen popup → stays dismissed (per `null` bucket).
4. Restore version reporting → Alert reappears (bucket no longer matches), then resolves once the protocol version is compatible.

### Forward-compat
1. In the desktop or server source, edit the JSON wire format to send `appType: "cli"` (or any unknown variant) from `/health` and/or `INITIAL_STATE`.
2. Reconnect. Expect: connection still completes; copy falls through to "Update" / "Connected"; About surface omits the type label.

### Privacy check
- Open the extension's network panel during the full flow. Confirm zero non-localhost requests. The "Update available" link opens a new tab — it's user-initiated navigation, not a fetch from the extension.

### Tooling
- `bun run sync-versions` should report `(no change)` for every line.
- Temporarily break one of the constant declarations (e.g. rename `PROTOCOL_VERSION` in `websocket.ts`) and re-run — expect the script to throw with an actionable error pointing at the regex.

## Related Issue

None — proactive improvement surfaced while reviewing how users recover from version drift.

---

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)