### PR TITLE
refactor(core,extension,protocol): rename streamingBufferMs to jitterBufferMs

### DIFF
--- a/.changeset/protocol-rename-jitter-buffer-ms.md
+++ b/.changeset/protocol-rename-jitter-buffer-ms.md
@@ -1,0 +1,12 @@
+---
+'@thaumic-cast/protocol': patch
+'@thaumic-cast/core': patch
+'@thaumic-cast/extension': patch
+'@thaumic-cast/desktop': patch
+---
+
+Rename `streamingBufferMs` setting to `jitterBufferMs` across the stack
+
+Pure rename — no behavior change. Every value, default, clamp range, and UI option stays the same. Identifier updated on the protocol, core, extension, and desktop surfaces, plus docstrings and the one user-facing label ("Streaming Buffer" → "Jitter Buffer"). The setting has always functioned as a jitter buffer (holding PCM frames to smooth WebSocket-to-Sonos delivery variance), so the name now matches the role.
+
+Sets up a follow-up change that turns this from a passive sizing hint into an active fill-gate / refill-on-underrun state machine.

--- a/apps/extension/src/lib/presets.ts
+++ b/apps/extension/src/lib/presets.ts
@@ -32,7 +32,7 @@ const log = createLogger('Presets');
 
 /**
  * Builds an encoder config from custom audio settings.
- * Applies defaults for optional fields (bitsPerSample, streamingBufferMs, frameDurationMs).
+ * Applies defaults for optional fields (bitsPerSample, jitterBufferMs, frameDurationMs).
  * @param customSettings - The custom audio settings from user preferences
  * @returns A complete encoder config
  */
@@ -46,7 +46,7 @@ function buildConfigFromCustomSettings(customSettings: CustomAudioSettings): Enc
     sampleRate: customSettings.sampleRate,
     bitsPerSample: customSettings.bitsPerSample ?? DEFAULT_BITS_PER_SAMPLE,
     latencyMode: customSettings.latencyMode,
-    streamingBufferMs: customSettings.streamingBufferMs ?? policy.streamingBufferMs,
+    jitterBufferMs: customSettings.jitterBufferMs ?? policy.jitterBufferMs,
     frameDurationMs: customSettings.frameDurationMs ?? FRAME_DURATION_MS_DEFAULT,
     // frameSizeSamples is computed by the audio worker based on codec-optimal frame size
   };
@@ -75,7 +75,7 @@ function getFallbackConfig(codecSupport: SupportedCodecsResult): EncoderConfig |
     channels: 2,
     bitsPerSample: DEFAULT_BITS_PER_SAMPLE,
     latencyMode: 'quality',
-    streamingBufferMs: policy.streamingBufferMs,
+    jitterBufferMs: policy.jitterBufferMs,
     frameDurationMs: FRAME_DURATION_MS_DEFAULT,
     // frameSizeSamples is computed by the audio worker based on codec-optimal frame size
   };
@@ -137,7 +137,7 @@ function buildConfigFromOption(
   const sampleRate = pickSampleRate(option.codec, codecSupport, tier === 'low');
   // Low tier uses mono for bandwidth savings
   const channels: 1 | 2 = tier === 'low' ? 1 : 2;
-  // Use policy-defined streaming buffer for server-side jitter tolerance
+  // Use policy-defined jitter buffer for server-side jitter tolerance
   const policy = getStreamingPolicy(latencyMode);
 
   return {
@@ -147,7 +147,7 @@ function buildConfigFromOption(
     channels,
     bitsPerSample: DEFAULT_BITS_PER_SAMPLE,
     latencyMode,
-    streamingBufferMs: policy.streamingBufferMs,
+    jitterBufferMs: policy.jitterBufferMs,
     frameDurationMs: FRAME_DURATION_MS_DEFAULT,
     // frameSizeSamples is computed by the audio worker based on codec-optimal frame size
   };

--- a/apps/extension/src/lib/settings.ts
+++ b/apps/extension/src/lib/settings.ts
@@ -6,9 +6,9 @@ import {
   LatencyModeSchema,
   BitDepthSchema,
   DEFAULT_BITS_PER_SAMPLE,
-  STREAMING_BUFFER_MS_MIN,
-  STREAMING_BUFFER_MS_MAX,
-  STREAMING_BUFFER_MS_DEFAULT,
+  JITTER_BUFFER_MS_MIN,
+  JITTER_BUFFER_MS_MAX,
+  JITTER_BUFFER_MS_DEFAULT,
   FRAME_DURATION_MS_DEFAULT,
   FrameDurationMsSchema,
   isValidBitrateForCodec,
@@ -144,12 +144,12 @@ export const CustomAudioSettingsSchema = z.object({
   latencyMode: LatencyModeSchema.default('quality'),
   /** Bit depth (16 or 24). Supported depths depend on the codec. */
   bitsPerSample: BitDepthSchema.default(DEFAULT_BITS_PER_SAMPLE),
-  /** Buffer size for PCM streaming in milliseconds. */
-  streamingBufferMs: z
+  /** Jitter buffer size for PCM streaming in milliseconds. */
+  jitterBufferMs: z
     .number()
-    .min(STREAMING_BUFFER_MS_MIN)
-    .max(STREAMING_BUFFER_MS_MAX)
-    .default(STREAMING_BUFFER_MS_DEFAULT),
+    .min(JITTER_BUFFER_MS_MIN)
+    .max(JITTER_BUFFER_MS_MAX)
+    .default(JITTER_BUFFER_MS_DEFAULT),
   /** Frame duration in milliseconds. Currently only used when codec is 'pcm'. */
   frameDurationMs: FrameDurationMsSchema.default(FRAME_DURATION_MS_DEFAULT),
 });
@@ -181,7 +181,7 @@ export const ExtensionSettingsSchema = z.object({
     sampleRate: 48000,
     latencyMode: 'quality',
     bitsPerSample: DEFAULT_BITS_PER_SAMPLE,
-    streamingBufferMs: STREAMING_BUFFER_MS_DEFAULT,
+    jitterBufferMs: JITTER_BUFFER_MS_DEFAULT,
     frameDurationMs: FRAME_DURATION_MS_DEFAULT,
   }),
 
@@ -215,7 +215,7 @@ const DEFAULT_EXTENSION_SETTINGS: ExtensionSettings = {
     sampleRate: 48000,
     latencyMode: 'quality',
     bitsPerSample: DEFAULT_BITS_PER_SAMPLE,
-    streamingBufferMs: STREAMING_BUFFER_MS_DEFAULT,
+    jitterBufferMs: JITTER_BUFFER_MS_DEFAULT,
     frameDurationMs: FRAME_DURATION_MS_DEFAULT,
   },
   videoSyncEnabled: false,

--- a/apps/extension/src/locales/en.json
+++ b/apps/extension/src/locales/en.json
@@ -106,7 +106,7 @@
   "audio_latency_mode": "Latency Mode",
   "audio_latency_quality": "Quality",
   "audio_latency_realtime": "Realtime",
-  "audio_streaming_buffer": "Streaming Buffer",
+  "audio_jitter_buffer": "Jitter Buffer",
   "audio_buffer_low": "Low latency",
   "audio_buffer_balanced": "Balanced",
   "audio_buffer_stable": "Stable",

--- a/apps/extension/src/options/components/AudioSection.tsx
+++ b/apps/extension/src/options/components/AudioSection.tsx
@@ -198,14 +198,14 @@ export function AudioSection({
   );
 
   /**
-   * Handles streaming buffer change (PCM only).
+   * Handles jitter buffer change (PCM only).
    */
-  const handleStreamingBufferChange = useCallback(
-    async (streamingBufferMs: number) => {
+  const handleJitterBufferChange = useCallback(
+    async (jitterBufferMs: number) => {
       await onUpdate({
         customAudioSettings: {
           ...settings.customAudioSettings,
-          streamingBufferMs,
+          jitterBufferMs,
         },
       });
     },
@@ -303,9 +303,9 @@ export function AudioSection({
 
     if (resolvedConfig.codec === 'pcm') {
       rows.push({
-        key: 'streaming-buffer',
-        label: t('audio_streaming_buffer'),
-        value: `${resolvedConfig.streamingBufferMs}ms`,
+        key: 'jitter-buffer',
+        label: t('audio_jitter_buffer'),
+        value: `${resolvedConfig.jitterBufferMs}ms`,
       });
       rows.push({
         key: 'frame-duration',
@@ -506,18 +506,18 @@ export function AudioSection({
                     <span className={styles.hint}>{t('audio_bit_depth_hint')}</span>
                   </div>
 
-                  {/* Streaming Buffer - only show for PCM codec */}
+                  {/* Jitter Buffer - only show for PCM codec */}
                   {settings.customAudioSettings.codec === 'pcm' && (
                     <div className={styles.field}>
-                      <label htmlFor="audio-streaming-buffer" className={styles.label}>
-                        {t('audio_streaming_buffer')}
+                      <label htmlFor="audio-jitter-buffer" className={styles.label}>
+                        {t('audio_jitter_buffer')}
                       </label>
                       <select
-                        id="audio-streaming-buffer"
+                        id="audio-jitter-buffer"
                         className={styles.select}
-                        value={settings.customAudioSettings.streamingBufferMs}
+                        value={settings.customAudioSettings.jitterBufferMs}
                         onChange={(e) =>
-                          handleStreamingBufferChange(Number((e.target as HTMLSelectElement).value))
+                          handleJitterBufferChange(Number((e.target as HTMLSelectElement).value))
                         }
                       >
                         <option value={100}>{t('audio_buffer_low')} (100ms)</option>

--- a/packages/protocol/src/audio.ts
+++ b/packages/protocol/src/audio.ts
@@ -166,12 +166,12 @@ export function tpdfDither(): number {
 }
 
 /**
- * Streaming buffer size constraints and default (in milliseconds).
+ * Jitter buffer size constraints and default (in milliseconds).
  * Used for PCM streaming to balance latency vs. reliability.
  */
-export const STREAMING_BUFFER_MS_MIN = 100;
-export const STREAMING_BUFFER_MS_MAX = 1000;
-export const STREAMING_BUFFER_MS_DEFAULT = 200;
+export const JITTER_BUFFER_MS_MIN = 100;
+export const JITTER_BUFFER_MS_MAX = 1000;
+export const JITTER_BUFFER_MS_DEFAULT = 200;
 
 /**
  * Frame duration options (in milliseconds).

--- a/packages/protocol/src/encoder.ts
+++ b/packages/protocol/src/encoder.ts
@@ -15,9 +15,9 @@ import {
   type LatencyMode,
   LatencyModeSchema,
   SampleRateSchema,
-  STREAMING_BUFFER_MS_DEFAULT,
-  STREAMING_BUFFER_MS_MAX,
-  STREAMING_BUFFER_MS_MIN,
+  JITTER_BUFFER_MS_DEFAULT,
+  JITTER_BUFFER_MS_MAX,
+  JITTER_BUFFER_MS_MIN,
   type SupportedSampleRate,
 } from './audio.js';
 
@@ -189,12 +189,12 @@ export const EncoderConfigSchema = z
      */
     bitsPerSample: BitDepthSchema.default(16),
     latencyMode: LatencyModeSchema.default('quality'),
-    /** Buffer size for PCM streaming in milliseconds. */
-    streamingBufferMs: z
+    /** Jitter buffer size for PCM streaming in milliseconds. */
+    jitterBufferMs: z
       .number()
-      .min(STREAMING_BUFFER_MS_MIN)
-      .max(STREAMING_BUFFER_MS_MAX)
-      .default(STREAMING_BUFFER_MS_DEFAULT),
+      .min(JITTER_BUFFER_MS_MIN)
+      .max(JITTER_BUFFER_MS_MAX)
+      .default(JITTER_BUFFER_MS_DEFAULT),
     /**
      * Frame duration in milliseconds for codecs that support configurable frame sizes.
      * Currently only used for PCM. Other codecs have fixed frame sizes.
@@ -231,8 +231,8 @@ export interface CreateEncoderConfigOptions {
   /** Bit depth (16 or 24). 24-bit only supported for FLAC. */
   bitsPerSample?: BitDepth;
   latencyMode?: LatencyMode;
-  /** Buffer size for PCM streaming in milliseconds (100-1000). */
-  streamingBufferMs?: number;
+  /** Jitter buffer size for PCM streaming in milliseconds (100-1000). */
+  jitterBufferMs?: number;
   /** Frame duration in milliseconds (10, 20, or 40). Currently only used for PCM codec. */
   frameDurationMs?: FrameDurationMs;
   /** Frame size in samples per channel. Set by audio worker. */
@@ -252,7 +252,7 @@ export function createEncoderConfig(options: CreateEncoderConfigOptions): Encode
     channels = 2,
     bitsPerSample = 16,
     latencyMode = 'quality',
-    streamingBufferMs = STREAMING_BUFFER_MS_DEFAULT,
+    jitterBufferMs = JITTER_BUFFER_MS_DEFAULT,
     frameDurationMs = FRAME_DURATION_MS_DEFAULT,
     frameSizeSamples,
   } = options;
@@ -269,7 +269,7 @@ export function createEncoderConfig(options: CreateEncoderConfigOptions): Encode
     channels,
     bitsPerSample: effectiveBitsPerSample,
     latencyMode,
-    streamingBufferMs,
+    jitterBufferMs,
     frameDurationMs,
     frameSizeSamples,
   };

--- a/packages/protocol/src/streaming-policy.ts
+++ b/packages/protocol/src/streaming-policy.ts
@@ -39,8 +39,8 @@ export interface StreamingPolicy {
   /** Backpressure: whether to drop frames (true) or pause (false). */
   dropOnBackpressure: boolean;
 
-  /** Server-side streaming buffer size (ms). Sent in handshake. */
-  streamingBufferMs: number;
+  /** Server-side jitter buffer size (ms). Sent in handshake. */
+  jitterBufferMs: number;
 }
 
 /**
@@ -54,7 +54,7 @@ const QUALITY_POLICY: StreamingPolicy = {
   maxEncodeQueue: 16, // More lenient queue
   wsBufferHighWater: 512_000, // 512KB before pausing
   dropOnBackpressure: false, // Queue frames instead of drop
-  streamingBufferMs: 500, // Larger server buffer for jitter tolerance
+  jitterBufferMs: 500, // Larger server buffer for jitter tolerance
 };
 
 /**
@@ -68,7 +68,7 @@ const REALTIME_POLICY: StreamingPolicy = {
   maxEncodeQueue: 8, // Tight queue
   wsBufferHighWater: 256_000, // 256KB before dropping
   dropOnBackpressure: true, // Drop to maintain timing
-  streamingBufferMs: 200, // Tighter server buffer for lower latency
+  jitterBufferMs: 200, // Tighter server buffer for lower latency
 };
 
 /**

--- a/packages/thaumic-core/src/api/stream.rs
+++ b/packages/thaumic-core/src/api/stream.rs
@@ -81,11 +81,11 @@ pub(super) async fn stream_audio(
     // Upfront buffering delay for PCM streams BEFORE subscribing.
     // This lets the ring buffer accumulate more frames. Subscribing after
     // ensures the broadcast receiver doesn't fill up during the delay.
-    // Delay matches streaming_buffer_ms so cadence queue starts full.
+    // Delay matches jitter_buffer_ms so cadence queue starts full.
     //
     // SKIP on resume: Sonos closes the connection within milliseconds if we delay.
     // The buffer already has frames from before the pause, so no delay is needed.
-    let prefill_delay_ms = stream_state.streaming_buffer_ms;
+    let prefill_delay_ms = stream_state.jitter_buffer_ms;
     if stream_state.codec == AudioCodec::Pcm && prefill_delay_ms > 0 && !is_resume {
         log::debug!(
             "[Stream] Applying {}ms prefill delay for PCM stream",
@@ -141,10 +141,10 @@ pub(super) async fn stream_audio(
         let frame_duration_ms = stream_state.frame_duration_ms;
         let silence_frame = stream_state.audio_format.silence_frame(frame_duration_ms);
 
-        // Calculate queue size from streaming buffer (ceil division)
+        // Calculate queue size from jitter buffer (ceil division)
         // queue_size = ceil(buffer_ms / frame_ms), clamped to [1, MAX_CADENCE_QUEUE_SIZE]
         let queue_size = stream_state
-            .streaming_buffer_ms
+            .jitter_buffer_ms
             .div_ceil(frame_duration_ms as u64) as usize;
         let queue_size = queue_size.clamp(1, MAX_CADENCE_QUEUE_SIZE);
 

--- a/packages/thaumic-core/src/api/ws.rs
+++ b/packages/thaumic-core/src/api/ws.rs
@@ -13,9 +13,9 @@ use std::time::{Duration, Instant};
 use crate::api::AppState;
 use crate::events::SpeakerRemovalReason;
 use crate::protocol_constants::{
-    DEFAULT_STREAMING_BUFFER_MS, MAX_FRAME_DURATION_MS, MAX_STREAMING_BUFFER_MS,
-    MIN_FRAME_DURATION_MS, MIN_STREAMING_BUFFER_MS, SILENCE_FRAME_DURATION_MS,
-    WS_HEARTBEAT_CHECK_INTERVAL_SECS, WS_HEARTBEAT_TIMEOUT_SECS,
+    DEFAULT_JITTER_BUFFER_MS, MAX_FRAME_DURATION_MS, MAX_JITTER_BUFFER_MS, MIN_FRAME_DURATION_MS,
+    MIN_JITTER_BUFFER_MS, SILENCE_FRAME_DURATION_MS, WS_HEARTBEAT_CHECK_INTERVAL_SECS,
+    WS_HEARTBEAT_TIMEOUT_SECS,
 };
 use crate::services::StreamCoordinator;
 use crate::stream::{AudioCodec, AudioFormat, StreamMetadata};
@@ -175,8 +175,8 @@ struct EncoderConfig {
     channels: Option<u8>,
     /// Bit depth for audio encoding (16 or 24). Only 24-bit is supported for FLAC.
     bits_per_sample: Option<u16>,
-    /// Streaming buffer size in milliseconds (100-1000). Only affects PCM codec.
-    streaming_buffer_ms: Option<u64>,
+    /// Jitter buffer size in milliseconds (100-1000). Only affects PCM codec.
+    jitter_buffer_ms: Option<u64>,
     /// Frame size in samples per channel.
     /// Server derives exact duration: duration_ms = samples * 1000 / sample_rate
     frame_size_samples: Option<u32>,
@@ -452,7 +452,7 @@ fn resolve_codec(codec_str: Option<&str>) -> AudioCodec {
 struct StreamConfig {
     codec: AudioCodec,
     audio_format: AudioFormat,
-    streaming_buffer_ms: u64,
+    jitter_buffer_ms: u64,
     frame_duration_ms: u32,
 }
 
@@ -496,12 +496,12 @@ fn parse_stream_config(payload: &HandshakeRequest) -> Result<StreamConfig, Strin
         }
     };
 
-    let streaming_buffer_ms = payload
+    let jitter_buffer_ms = payload
         .encoder_config
         .as_ref()
-        .and_then(|c| c.streaming_buffer_ms)
-        .unwrap_or(DEFAULT_STREAMING_BUFFER_MS)
-        .clamp(MIN_STREAMING_BUFFER_MS, MAX_STREAMING_BUFFER_MS);
+        .and_then(|c| c.jitter_buffer_ms)
+        .unwrap_or(DEFAULT_JITTER_BUFFER_MS)
+        .clamp(MIN_JITTER_BUFFER_MS, MAX_JITTER_BUFFER_MS);
 
     // Derive frame duration from frame_size_samples.
     // Using samples avoids floating-point rounding errors in the extension.
@@ -543,7 +543,7 @@ fn parse_stream_config(payload: &HandshakeRequest) -> Result<StreamConfig, Strin
     Ok(StreamConfig {
         codec,
         audio_format: AudioFormat::new(sample_rate, channels as u16, bits_per_sample),
-        streaming_buffer_ms,
+        jitter_buffer_ms,
         frame_duration_ms,
     })
 }
@@ -559,14 +559,14 @@ fn handle_handshake(state: &AppState, payload: HandshakeRequest) -> HandshakeRes
         "[WS] Creating stream: codec={:?}, format={:?}, buffer={}ms, frame={}ms",
         config.codec,
         config.audio_format,
-        config.streaming_buffer_ms,
+        config.jitter_buffer_ms,
         config.frame_duration_ms
     );
 
     match state.stream_coordinator.create_stream(
         config.codec,
         config.audio_format,
-        config.streaming_buffer_ms,
+        config.jitter_buffer_ms,
         config.frame_duration_ms,
     ) {
         Ok(id) => HandshakeResult::Success(id),
@@ -694,7 +694,7 @@ async fn handle_start_browser_capture(
         source,
         stream_config.codec,
         stream_config.audio_format,
-        stream_config.streaming_buffer_ms,
+        stream_config.jitter_buffer_ms,
         stream_config.frame_duration_ms,
         Some(metadata),
     ) {

--- a/packages/thaumic-core/src/protocol_constants.rs
+++ b/packages/thaumic-core/src/protocol_constants.rs
@@ -121,17 +121,17 @@ pub const MIN_FRAME_DURATION_MS: u32 = 5;
 pub const MAX_FRAME_DURATION_MS: u32 = 150;
 
 /// Frame size constraints (samples per channel).
-/// Minimum streaming buffer size (ms).
-pub const MIN_STREAMING_BUFFER_MS: u64 = 100;
+/// Minimum jitter buffer size (ms).
+pub const MIN_JITTER_BUFFER_MS: u64 = 100;
 
-/// Maximum streaming buffer size (ms).
-pub const MAX_STREAMING_BUFFER_MS: u64 = 1000;
+/// Maximum jitter buffer size (ms).
+pub const MAX_JITTER_BUFFER_MS: u64 = 1000;
 
-/// Default streaming buffer size (ms).
-pub const DEFAULT_STREAMING_BUFFER_MS: u64 = 200;
+/// Default jitter buffer size (ms).
+pub const DEFAULT_JITTER_BUFFER_MS: u64 = 200;
 
 /// Maximum cadence queue size (frames).
 /// Calculated using MIN_FRAME_DURATION_MS to ensure buffer can hold enough frames
 /// at the smallest possible frame duration.
 pub const MAX_CADENCE_QUEUE_SIZE: usize =
-    (MAX_STREAMING_BUFFER_MS / MIN_FRAME_DURATION_MS as u64) as usize;
+    (MAX_JITTER_BUFFER_MS / MIN_FRAME_DURATION_MS as u64) as usize;

--- a/packages/thaumic-core/src/services/stream_coordinator.rs
+++ b/packages/thaumic-core/src/services/stream_coordinator.rs
@@ -350,7 +350,7 @@ impl StreamCoordinator {
     /// # Arguments
     /// * `codec` - Output codec for HTTP Content-Type (what Sonos receives)
     /// * `audio_format` - Audio format configuration (sample rate, channels, bit depth)
-    /// * `streaming_buffer_ms` - Streaming buffer size in milliseconds (100-1000)
+    /// * `jitter_buffer_ms` - Jitter buffer size in milliseconds (100-1000)
     /// * `frame_duration_ms` - Frame duration in milliseconds for cadence timing
     ///
     /// Returns the stream ID on success. Broadcasts a `StreamEvent::Created` event.
@@ -358,13 +358,13 @@ impl StreamCoordinator {
         &self,
         codec: AudioCodec,
         audio_format: AudioFormat,
-        streaming_buffer_ms: u64,
+        jitter_buffer_ms: u64,
         frame_duration_ms: u32,
     ) -> Result<String, String> {
         let stream_id = self.stream_registry.create_stream(
             codec,
             audio_format,
-            streaming_buffer_ms,
+            jitter_buffer_ms,
             frame_duration_ms,
         )?;
 
@@ -391,12 +391,12 @@ impl StreamCoordinator {
         source: Arc<dyn AudioSource>,
         codec: AudioCodec,
         audio_format: AudioFormat,
-        streaming_buffer_ms: u64,
+        jitter_buffer_ms: u64,
         frame_duration_ms: u32,
         metadata: Option<StreamMetadata>,
     ) -> Result<CaptureStreamSession, String> {
         let stream_id =
-            self.create_stream(codec, audio_format, streaming_buffer_ms, frame_duration_ms)?;
+            self.create_stream(codec, audio_format, jitter_buffer_ms, frame_duration_ms)?;
 
         if let Some(meta) = metadata {
             self.update_metadata(&stream_id, meta);

--- a/packages/thaumic-core/src/stream/manager.rs
+++ b/packages/thaumic-core/src/stream/manager.rs
@@ -274,9 +274,9 @@ pub struct StreamState {
     has_frames: AtomicBool,
     /// Timing information for latency measurement.
     pub timing: StreamTiming,
-    /// Streaming buffer size in milliseconds (100-1000, default 200).
+    /// Jitter buffer size in milliseconds (100-1000, default 200).
     /// Used to calculate cadence queue size for PCM streams.
-    pub streaming_buffer_ms: u64,
+    pub jitter_buffer_ms: u64,
     /// Frame duration in milliseconds for cadence timing.
     /// Determines silence frame duration and cadence tick interval.
     pub frame_duration_ms: u32,
@@ -295,7 +295,7 @@ impl StreamState {
     /// * `audio_format` - Audio format configuration (sample rate, channels, bit depth)
     /// * `buffer_frames` - Maximum frames to buffer for late-joining clients
     /// * `channel_capacity` - Capacity of the broadcast channel for audio frames
-    /// * `streaming_buffer_ms` - Streaming buffer size in milliseconds (100-1000)
+    /// * `jitter_buffer_ms` - Jitter buffer size in milliseconds (100-1000)
     /// * `frame_duration_ms` - Frame duration in milliseconds for cadence timing
     pub fn new(
         id: String,
@@ -303,7 +303,7 @@ impl StreamState {
         audio_format: AudioFormat,
         buffer_frames: usize,
         channel_capacity: usize,
-        streaming_buffer_ms: u64,
+        jitter_buffer_ms: u64,
         frame_duration_ms: u32,
     ) -> Self {
         let (tx, _) = broadcast::channel(channel_capacity);
@@ -312,7 +312,7 @@ impl StreamState {
             id,
             codec,
             audio_format,
-            streaming_buffer_ms,
+            jitter_buffer_ms,
             frame_duration_ms
         );
         Self {
@@ -327,7 +327,7 @@ impl StreamState {
             buffer_frames,
             has_frames: AtomicBool::new(false),
             timing: StreamTiming::new(),
-            streaming_buffer_ms,
+            jitter_buffer_ms,
             frame_duration_ms,
             last_push_at: parking_lot::Mutex::new(None),
             receive_stats: parking_lot::Mutex::new(ReceiveStats::new()),
@@ -478,13 +478,13 @@ impl StreamRegistry {
     /// # Arguments
     /// * `codec` - Output codec for HTTP Content-Type (what Sonos receives)
     /// * `audio_format` - Audio format configuration (sample rate, channels, bit depth)
-    /// * `streaming_buffer_ms` - Streaming buffer size in milliseconds (100-1000)
+    /// * `jitter_buffer_ms` - Jitter buffer size in milliseconds (100-1000)
     /// * `frame_duration_ms` - Frame duration in milliseconds for cadence timing
     pub fn create_stream(
         &self,
         codec: AudioCodec,
         audio_format: AudioFormat,
-        streaming_buffer_ms: u64,
+        jitter_buffer_ms: u64,
         frame_duration_ms: u32,
     ) -> Result<String, String> {
         if self.streams.len() >= self.config.max_concurrent_streams {
@@ -498,7 +498,7 @@ impl StreamRegistry {
             audio_format,
             self.config.buffer_frames,
             self.config.channel_capacity,
-            streaming_buffer_ms,
+            jitter_buffer_ms,
             frame_duration_ms,
         ));
         self.streams.insert(id.clone(), state);


### PR DESCRIPTION
## What

Pure rename across the stack — no behavior change. Every value, default, clamp range, and UI option is preserved. Only identifiers, docstrings, and one user-facing label change.

**Rust:**
- `MIN/MAX/DEFAULT_STREAMING_BUFFER_MS` → `MIN/MAX/DEFAULT_JITTER_BUFFER_MS`
- `StreamState::streaming_buffer_ms` → `StreamState::jitter_buffer_ms`
- `create_stream()` and `start_capture_stream()` parameter rename
- `StreamConfig.streaming_buffer_ms` → `StreamConfig.jitter_buffer_ms`

**TypeScript:**
- `STREAMING_BUFFER_MS_{MIN,MAX,DEFAULT}` → `JITTER_BUFFER_MS_{MIN,MAX,DEFAULT}`
- `EncoderConfig.streamingBufferMs` → `EncoderConfig.jitterBufferMs`
- `StreamingPolicy.streamingBufferMs` → `StreamingPolicy.jitterBufferMs`
- `CustomAudioSettings.streamingBufferMs` → `CustomAudioSettings.jitterBufferMs`

**i18n / UI:**
- `audio_streaming_buffer` key → `audio_jitter_buffer`
- "Streaming Buffer" label → "Jitter Buffer"
- Option labels ("Low latency", "Balanced", "Stable", "Maximum stability") preserved

## Why

The setting has always behaved as a jitter buffer — holding PCM frames to smooth delivery variance between the WebSocket producer and the Sonos HTTP consumer — so "jitter buffer" is more accurate naming. This rename also sets up a follow-up PR that turns this from a passive sizing hint into an active fill-gate / refill-on-underrun state machine with a proper `BufferState` lifecycle; landing the rename first keeps that PR's diff focused on behavior instead of carrying the rename noise.

## How to Test

- `cargo test -p thaumic-core --lib` (197 pass locally).
- `cargo clippy -p thaumic-core --lib --tests -- -D warnings` (clean).
- `bun run typecheck` (clean).
- Load the extension, open Options → Audio Section, confirm PCM codec still shows the buffer dropdown. Label now reads "Jitter Buffer"; option labels and values (100ms / 200ms / 500ms / 1000ms) unchanged.
- **Upgrade path:** existing users with `streamingBufferMs: 500` in storage will see Zod default kick in (field not recognized under the new schema), landing on `jitterBufferMs: 200` (the default). Confirm this is acceptable — no explicit migration is included since the value set is all inside the same clamp range and the UI dropdown preserves the same presets.

## Related Issue

Prep work for the jitter buffer state-machine PR that follows.

---

- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)