### PR TITLE
fix(extension,desktop): stop version-mismatch warning flashing on connect

### DIFF
--- a/.changeset/ext-version-mismatch-polish.md
+++ b/.changeset/ext-version-mismatch-polish.md
@@ -1,11 +1,13 @@
 ---
+'@thaumic-cast/protocol': patch
 '@thaumic-cast/extension': patch
 '@thaumic-cast/desktop': patch
 '@thaumic-cast/server': patch
 ---
 
-Polish the companion version-mismatch surface introduced in the previous release.
+Polish the companion version-mismatch surface introduced in the previous release, and unblock the path that was supposed to surface it for older companions.
 
+- Accept `INITIAL_STATE` payloads that omit `groupVolumeFixed`. That field was added after the initial protocol shipped; older companions don't send it, so the extension's `WS_CONNECTED` route rejected their messages at schema validation — `handleWsConnected` never ran, the popup stayed stuck at "Checking…", and the out-of-date warning (the very UI meant for this scenario) never had a chance to render. The `groupVolumeFixed` field now defaults to an empty map when missing, so older-companion payloads validate and the version-mismatch flow fires as designed.
 - Prevent the out-of-date warning Alert from briefly flashing on every initial connection. The popup was flipping `phase` to `'connected'` optimistically on `WS_STATE_CHANGED` before the async fetch that carries the companion metadata resolved, so `protocolVersion` was transiently `null` and the mismatch helper would light up the Alert for a single render. The connection-status hook now only transitions to `'connected'` via the metadata-bearing `CACHED_STATE_RECEIVED`, applying phase and metadata atomically. The companion-version hook additionally gates on `phase === 'connected'` so no flash window can open between discovery and WebSocket `INITIAL_STATE`.
 - Gate the Alert on the persisted dismissal record having loaded, closing a smaller race where a previously-dismissed warning briefly reappeared on popup open before `chrome.storage.local` resolved.
 - Rename the protocol line in the extension About card and the desktop Settings About card from `Protocol v{{version}}` to `Protocol · Version {{version}}`, matching the adjacent `Desktop App · Version {{version}}` / `Version {{version}}` format.

--- a/.changeset/ext-version-mismatch-polish.md
+++ b/.changeset/ext-version-mismatch-polish.md
@@ -1,0 +1,11 @@
+---
+'@thaumic-cast/extension': patch
+'@thaumic-cast/desktop': patch
+'@thaumic-cast/server': patch
+---
+
+Polish the companion version-mismatch surface introduced in the previous release.
+
+- Prevent the out-of-date warning Alert from briefly flashing on every initial connection. The popup was flipping `phase` to `'connected'` optimistically on `WS_STATE_CHANGED` before the async fetch that carries the companion metadata resolved, so `protocolVersion` was transiently `null` and the mismatch helper would light up the Alert for a single render. The connection-status hook now only transitions to `'connected'` via the metadata-bearing `CACHED_STATE_RECEIVED`, applying phase and metadata atomically. The companion-version hook additionally gates on `phase === 'connected'` so no flash window can open between discovery and WebSocket `INITIAL_STATE`.
+- Gate the Alert on the persisted dismissal record having loaded, closing a smaller race where a previously-dismissed warning briefly reappeared on popup open before `chrome.storage.local` resolved.
+- Rename the protocol line in the extension About card and the desktop Settings About card from `Protocol v{{version}}` to `Protocol · Version {{version}}`, matching the adjacent `Desktop App · Version {{version}}` / `Version {{version}}` format.

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -60,7 +60,7 @@
   "settings.about": "About",
   "settings.about_app": "Thaumic Cast Desktop",
   "settings.about_version": "Version {{version}}",
-  "settings.about_protocol": "Protocol v{{version}}",
+  "settings.about_protocol": "Protocol · Version {{version}}",
   "settings.check_for_updates": "Check for updates",
   "settings.check_for_updates_description": "Opens the releases page in your browser",
 

--- a/apps/extension/src/locales/en.json
+++ b/apps/extension/src/locales/en.json
@@ -148,7 +148,7 @@
   "about_companion_type_desktop": "Desktop App",
   "about_companion_type_server": "Server",
   "about_companion_type_generic": "Desktop App or Server",
-  "about_companion_protocol": "Protocol v{{version}}",
+  "about_companion_protocol": "Protocol · Version {{version}}",
   "about_companion_unknown_version": "Unknown version",
 
   "version_mismatch_message": "Your {{appTypeLabel}} has fallen behind the extension (currently v{{appVersion}}). Update to restore harmony.",

--- a/apps/extension/src/popup/hooks/useCompanionVersion.ts
+++ b/apps/extension/src/popup/hooks/useCompanionVersion.ts
@@ -41,11 +41,13 @@ export interface UseCompanionVersionResult {
  */
 export function useCompanionVersion(connection: ConnectionStatus): UseCompanionVersionResult {
   const [dismissed, setDismissed] = useState<DismissedCompanionVersion | null>(null);
+  const [dismissedLoaded, setDismissedLoaded] = useState(false);
 
   useEffect(() => {
     getDismissedCompanionVersion()
       .then(setDismissed)
-      .catch(() => setDismissed(null));
+      .catch(() => setDismissed(null))
+      .finally(() => setDismissedLoaded(true));
   }, []);
 
   useStorageListener<DismissedCompanionVersion>(
@@ -53,16 +55,19 @@ export function useCompanionVersion(connection: ConnectionStatus): UseCompanionV
     setDismissed,
   );
 
-  // Build a CompanionInfo only when we have a live connection. Without one,
-  // the version-check helpers should treat the popup as "no companion seen
-  // yet" — the connection-state fields are stale until reconnect.
-  const companion: CompanionInfo | null = connection.desktopAppUrl
-    ? {
-        appType: connection.appType,
-        appVersion: connection.appVersion,
-        protocolVersion: connection.protocolVersion,
-      }
-    : null;
+  // Only build a CompanionInfo once the WebSocket is actually connected.
+  // Between discovery and WS connect, `desktopAppUrl` is populated but
+  // `protocolVersion` is still null (INITIAL_STATE hasn't arrived yet) —
+  // treating that as a mismatch would flash the warning on every fresh
+  // connection.
+  const companion: CompanionInfo | null =
+    connection.phase === 'connected'
+      ? {
+          appType: connection.appType,
+          appVersion: connection.appVersion,
+          protocolVersion: connection.protocolVersion,
+        }
+      : null;
 
   const dismissMismatchWarning = useCallback(() => {
     if (!companion) return;
@@ -76,7 +81,10 @@ export function useCompanionVersion(connection: ConnectionStatus): UseCompanionV
   return {
     companion,
     hasMismatch: hasVersionMismatch(companion),
-    showMismatchWarning: shouldWarnAboutVersion(companion, dismissed),
+    // Suppress the Alert until the dismissal record has loaded from storage,
+    // otherwise a previously-dismissed bucket would flash the Alert on every
+    // popup open before `getDismissedCompanionVersion()` resolves.
+    showMismatchWarning: dismissedLoaded && shouldWarnAboutVersion(companion, dismissed),
     dismissMismatchWarning,
   };
 }

--- a/apps/extension/src/popup/hooks/useConnectionStatus.ts
+++ b/apps/extension/src/popup/hooks/useConnectionStatus.ts
@@ -65,7 +65,6 @@ type ConnectionAction =
   | { type: 'CACHED_STATE_RECEIVED'; payload: BackgroundConnectionState }
   | { type: 'CONNECTION_RESPONSE'; payload: EnsureConnectionResponse }
   | { type: 'RUNTIME_ERROR'; error: string }
-  | { type: 'WS_CONNECTED' }
   | { type: 'WS_RECONNECTING' }
   | { type: 'WS_PERMANENTLY_LOST' }
   | { type: 'CONNECTION_FAILED'; error: string; canRetry: boolean }
@@ -151,9 +150,6 @@ function connectionReducer(state: ConnectionState, action: ConnectionAction): Co
     case 'RUNTIME_ERROR':
       return { ...state, phase: 'error', error: action.error, canRetry: false };
 
-    case 'WS_CONNECTED':
-      return { ...state, phase: 'connected', error: null, canRetry: false };
-
     case 'WS_RECONNECTING':
       return { ...state, phase: 'reconnecting', error: null, canRetry: false };
 
@@ -229,9 +225,12 @@ export function useConnectionStatus(): ConnectionStatus {
     const msg = message as { type: string; [key: string]: unknown };
     switch (msg.type) {
       case 'WS_STATE_CHANGED':
-        dispatch({ type: 'WS_CONNECTED' });
-        // Fetch connection metadata in case ENSURE_CONNECTION response hasn't arrived yet
-        // (race condition: WS connects before response is processed)
+        // Fetch the full connection state and apply it atomically — flipping
+        // phase to 'connected' without the companion metadata (appType,
+        // appVersion, protocolVersion) would briefly make the version-check
+        // helpers see `protocolVersion: null` and flash the mismatch warning.
+        // Also covers the case where ENSURE_CONNECTION's response hasn't
+        // arrived yet (WS connects first).
         chrome.runtime
           .sendMessage({ type: 'GET_CONNECTION_STATUS' })
           .then((status: BackgroundConnectionState) => {

--- a/packages/protocol/src/sonos.ts
+++ b/packages/protocol/src/sonos.ts
@@ -73,7 +73,10 @@ export const SonosStateSnapshotSchema = z.object({
   transportStates: z.record(z.string(), TransportStateSchema),
   groupVolumes: z.record(z.string(), z.number()),
   groupMutes: z.record(z.string(), z.boolean()),
-  groupVolumeFixed: z.record(z.string(), z.boolean()),
+  // Added after the initial protocol shipped; older companions omit it.
+  // Default to an empty map so their payloads still validate and the
+  // version-mismatch warning path can run.
+  groupVolumeFixed: z.record(z.string(), z.boolean()).default({}),
   sessions: z.array(PlaybackSessionSchema).optional(),
 });
 export type SonosStateSnapshot = z.infer<typeof SonosStateSnapshotSchema>;
@@ -111,7 +114,10 @@ export const InitialStatePayloadSchema = z.object({
   transportStates: z.record(z.string(), TransportStateSchema),
   groupVolumes: z.record(z.string(), z.number()),
   groupMutes: z.record(z.string(), z.boolean()),
-  groupVolumeFixed: z.record(z.string(), z.boolean()),
+  // Added after the initial protocol shipped; older companions omit it.
+  // Default to an empty map so their payloads still validate and the
+  // version-mismatch warning path can run.
+  groupVolumeFixed: z.record(z.string(), z.boolean()).default({}),
   sessions: z.array(PlaybackSessionSchema).optional(),
   /** Wire-protocol semver — absent on companions predating 0.4.0. */
   protocolVersion: z.string().optional().catch(undefined),


### PR DESCRIPTION
## What

Two polish follow-ups to PR #103 (companion version metadata + out-of-date warnings).

**Flash fix.** The popup's out-of-date Alert briefly flashed on every fresh connection. Two races combined to cause it:

1. In `useConnectionStatus`, `WS_STATE_CHANGED` dispatched an optimistic `WS_CONNECTED` action that flipped `phase: 'connected'` synchronously, while `appVersion`/`protocolVersion` stayed at their previous (null) values until the async `GET_CONNECTION_STATUS` fetch resolved with `CACHED_STATE_RECEIVED`. During that window, `hasVersionMismatch` saw `protocolVersion: null` on a "connected" phase and fired the Alert.
2. In `useCompanionVersion`, `CompanionInfo` was built as soon as `connection.desktopAppUrl` was set — which happens after `/health` discovery but before the WebSocket's `INITIAL_STATE`. Same symptom.

Fixes:

- Drop the optimistic dispatch; let `CACHED_STATE_RECEIVED` apply phase and metadata atomically. Remove the now-unused `WS_CONNECTED` reducer action/case.
- In `useCompanionVersion`, gate `companion` on `phase === 'connected'` (matches `AboutSection.tsx`).
- Also gate `showMismatchWarning` on the dismissal record having loaded from `chrome.storage.local`, closing a smaller race where a previously-dismissed bucket briefly flashed the Alert on popup open.

**Copy polish.** The About cards in both the extension popup options and the desktop Settings view now render the protocol line as `Protocol · Version X.Y.Z` (was `Protocol vX.Y.Z`), matching the adjacent `Desktop App · Version X.Y.Z` / `Version X.Y.Z` format.

## Why

The flashing Alert on every new connection was an annoying regression introduced by the version-metadata work. It showed up on the compatible path too (where nothing is actually wrong), eroding user trust in the warning and drawing the eye to content that vanishes a frame later.

The copy change is a minor consistency fix — the old `Protocol vX.Y.Z` line was the only surface in either app that used the `v` prefix instead of the `Version X.Y.Z` spelling the rest of the About layout uses.

## How to Test

### Flash fix — compatible path
1. Build extension + desktop at matching versions.
2. Open the popup while the background is still discovering (easy: reload the extension, then open the popup within ~1 second). Watch the Alert area.
3. Expect: no flash of the "version mismatch" warning at any point. Footer transitions directly from "Checking…" to "Connected to Desktop App".

### Flash fix — pre-0.4.0 path (still warns, no flash)
1. In `apps/extension/src/offscreen/control-connection.ts`, temporarily force `appVersion`/`protocolVersion` to `null` when sending `WS_CONNECTED`.
2. Reconnect. Expect: warning Alert appears **only after** phase becomes `connected` — no flash during `checking`, no flash during the `GET_CONNECTION_STATUS` round-trip. Once connected, the "Your app predates this extension…" Alert is stable.

### Flash fix — dismissal-load race
1. Dismiss the warning (simulate mismatch via `MIN_COMPATIBLE_PROTOCOL_VERSION` bump, dismiss, then revert the bump isn't quite right — easier: set `MIN_COMPATIBLE_PROTOCOL_VERSION` above companion's protocol, dismiss, close popup).
2. Reopen the popup repeatedly. Expect: no flash of the Alert before `chrome.storage.local` resolves. Footer "Update available" link still appears (it's `hasMismatch`-gated, not dismissal-gated).

### Copy
1. Extension options → About: second line under "Connected Companion" should read `Protocol · Version 0.4.0`.
2. Desktop Settings → About: second line should read `Protocol · Version 0.4.0`.

## Related Issue

None — polish follow-up to #103.

---

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)