### PR TITLE
feat(extension): alert on LoopbackStream frame drops, suggest WASAPI capture

### DIFF
--- a/.changeset/ext-capture-health-alert.md
+++ b/.changeset/ext-capture-health-alert.md
@@ -1,0 +1,9 @@
+---
+'@thaumic-cast/extension': minor
+---
+
+Detect Chrome LoopbackStream frame drops and suggest WASAPI browser capture
+
+Adds an edge-triggered capture-health detector to `StreamSession` that watches `AudioData` timestamp gaps. On low-core Windows devices Chrome's LoopbackStream drops whole audio frames (~9 ms each), which is audible as stuttering; sustained detection surfaces a dismissible popup alert pointing the user at Advanced settings to enable Browser-wide capture, which bypasses LoopbackStream entirely. Degradation and recovery both flow through a new `CAPTURE_HEALTH_EVENT` → `CAPTURE_HEALTH_CHANGED` broadcast modelled on the existing network-health pipeline.
+
+Detection is currently limited to the tab-capture + PCM path (the only worker that emits `gapCount`). Parity for Opus/AAC/FLAC/Vorbis is tracked as follow-up work.

--- a/apps/extension/src/background/capture-health-state.ts
+++ b/apps/extension/src/background/capture-health-state.ts
@@ -1,0 +1,96 @@
+/**
+ * Capture Health State Module
+ *
+ * Tracks whether the active tab-capture session is experiencing frame-drop
+ * degradation (Chrome's LoopbackStream drops whole AudioData frames on
+ * low-core Windows devices — ~9188µs per drop at 48kHz, bursty on affected
+ * hardware, near-zero on healthy). `StreamSession` fires an edge-triggered
+ * event on each rising/falling transition; this module caches the latest
+ * snapshot so a freshly opened popup can render the alert without waiting
+ * for the next transition.
+ *
+ * State is ephemeral (not persisted) — it clears when the session ends.
+ */
+
+import { createLogger } from '@thaumic-cast/shared';
+import type { CaptureHealthChangedMessage } from '../lib/message-schemas';
+
+const log = createLogger('CaptureHealthState');
+
+export interface CaptureHealthState {
+  /** Whether the active session is currently degraded. */
+  degraded: boolean;
+  /** Tab ID of the session reporting degradation, or null when healthy/idle. */
+  tabId: number | null;
+  /**
+   * `Date.now()` stamp when the latest rising edge was observed. Used by the
+   * popup as an event identity for dismissal — a new `detectedAt` means a
+   * fresh detection event, even if the user already dismissed a prior one.
+   */
+  detectedAt: number | null;
+}
+
+let state: CaptureHealthState = {
+  degraded: false,
+  tabId: null,
+  detectedAt: null,
+};
+
+/**
+ * Returns the current capture-health snapshot (read-only copy).
+ * @returns The current capture-health snapshot
+ */
+export function getCaptureHealthState(): CaptureHealthState {
+  return { ...state };
+}
+
+/**
+ * Applies a capture-health edge event from a session. Rising edges set the
+ * tracked tab and timestamp. Falling edges only clear when they come from
+ * the currently tracked tab — otherwise a recovery event from Tab B would
+ * wipe Tab A's still-valid degradation.
+ * @param tabId - The tab ID that reported the transition
+ * @param degraded - Whether the session is now degraded
+ * @param detectedAt - Timestamp of the edge (Date.now from session)
+ * @returns True if state actually changed (caller should broadcast)
+ */
+export function applyCaptureHealthEvent(
+  tabId: number,
+  degraded: boolean,
+  detectedAt: number,
+): boolean {
+  if (degraded) {
+    state = { degraded: true, tabId, detectedAt };
+    log.info(`Capture degraded on tab ${tabId} at ${detectedAt}`);
+    return true;
+  }
+
+  if (state.tabId !== tabId) return false;
+
+  state = { degraded: false, tabId: null, detectedAt: null };
+  log.info(`Capture recovered on tab ${tabId}`);
+  return true;
+}
+
+/**
+ * Clears the capture-health state. Called when the associated session ends
+ * so the next session starts with a clean slate.
+ * @param tabId - Tab whose session is ending; no-op if it isn't the tracked tab
+ * @returns True if state actually changed (caller should broadcast)
+ */
+export function clearCaptureHealthForTab(tabId: number): boolean {
+  if (state.tabId !== tabId) return false;
+  state = { degraded: false, tabId: null, detectedAt: null };
+  return true;
+}
+
+/**
+ * Builds the popup broadcast payload from the current state. Single source
+ * of truth for the `CAPTURE_HEALTH_CHANGED` shape — callers that mutate
+ * state via {@link applyCaptureHealthEvent} or {@link clearCaptureHealthForTab}
+ * should broadcast by passing this result to `notifyPopup`.
+ * @returns The broadcast message reflecting the current state
+ */
+export function captureHealthBroadcast(): CaptureHealthChangedMessage {
+  return { type: 'CAPTURE_HEALTH_CHANGED', ...state };
+}

--- a/apps/extension/src/background/routes/connection-routes.ts
+++ b/apps/extension/src/background/routes/connection-routes.ts
@@ -7,6 +7,7 @@
 
 import { registerRoute, registerValidatedRoute } from '../router';
 import { getConnectionState } from '../connection-state';
+import { getCaptureHealthState } from '../capture-health-state';
 import { ensureConnection, handleWsConnectRequest } from '../handlers/connection';
 import { offscreenBroker } from '../offscreen-broker';
 import { WsConnectMessageSchema, WsReconnectMessageSchema } from '../../lib/message-schemas';
@@ -17,6 +18,10 @@ import { WsConnectMessageSchema, WsReconnectMessageSchema } from '../../lib/mess
 export function registerConnectionRoutes(): void {
   registerRoute('GET_CONNECTION_STATUS', () => {
     return getConnectionState();
+  });
+
+  registerRoute('GET_CAPTURE_HEALTH', () => {
+    return getCaptureHealthState();
   });
 
   registerRoute('ENSURE_CONNECTION', async () => {

--- a/apps/extension/src/background/routes/offscreen-routes.ts
+++ b/apps/extension/src/background/routes/offscreen-routes.ts
@@ -27,9 +27,15 @@ import {
   TopologyEventMessageSchema,
   SessionDisconnectedMessageSchema,
   BrowserCaptureErrorMessageSchema,
+  CaptureHealthEventMessageSchema,
 } from '../../lib/message-schemas';
 import { stopCastForTab } from '../sonos-event-handlers';
 import { notifyPopup } from '../notification-service';
+import {
+  applyCaptureHealthEvent,
+  captureHealthBroadcast,
+  clearCaptureHealthForTab,
+} from '../capture-health-state';
 import type { CastAutoStopReason } from '../../lib/message-schemas';
 
 const log = createLogger('OffscreenRoutes');
@@ -86,8 +92,19 @@ export function registerOffscreenRoutes(): void {
     if (hasSession(tabId)) {
       log.warn(`Session for tab ${tabId} disconnected unexpectedly`);
       removeSession(tabId);
+    } else if (clearCaptureHealthForTab(tabId)) {
+      // Session never reached START_PLAYBACK — removeSession skipped it, so
+      // drop capture-health state directly to avoid a stale degraded alert.
+      notifyPopup(captureHealthBroadcast());
     }
 
+    return { success: true };
+  });
+
+  registerValidatedRoute('CAPTURE_HEALTH_EVENT', CaptureHealthEventMessageSchema, (msg) => {
+    if (applyCaptureHealthEvent(msg.tabId, msg.degraded, msg.detectedAt)) {
+      notifyPopup(captureHealthBroadcast());
+    }
     return { success: true };
   });
 

--- a/apps/extension/src/background/session-manager.ts
+++ b/apps/extension/src/background/session-manager.ts
@@ -18,6 +18,7 @@ import { createLogger } from '@thaumic-cast/shared';
 import { getCachedState } from './metadata-cache';
 import { notifyPopup } from './notification-service';
 import { persistenceManager } from './persistence-manager';
+import { captureHealthBroadcast, clearCaptureHealthForTab } from './capture-health-state';
 
 const log = createLogger('SessionManager');
 
@@ -185,6 +186,12 @@ export function removeSession(tabId: number): void {
     // Release keep-awake when no sessions remain
     if (sessions.size === 0) {
       releaseKeepAwake();
+    }
+
+    // Drop any capture-health state tied to this session so the popup's
+    // alert clears as soon as the cast stops.
+    if (clearCaptureHealthForTab(tabId)) {
+      notifyPopup(captureHealthBroadcast());
     }
 
     persistSessions();

--- a/apps/extension/src/lib/message-schemas.ts
+++ b/apps/extension/src/lib/message-schemas.ts
@@ -478,6 +478,40 @@ export const NetworkHealthChangedMessageSchema = z.object({
 });
 export type NetworkHealthChangedMessage = z.infer<typeof NetworkHealthChangedMessageSchema>;
 
+/**
+ * Capture-health event (offscreen → background). Fired when `StreamSession`
+ * detects a transition between healthy and degraded tab-capture, where
+ * degraded = Chrome's LoopbackStream is dropping AudioData frames on a
+ * low-core Windows device. Only emitted on tab-capture + PCM sessions.
+ */
+export const CaptureHealthEventMessageSchema = z.object({
+  type: z.literal('CAPTURE_HEALTH_EVENT'),
+  tabId: TabIdSchema,
+  degraded: z.boolean(),
+  /** `Date.now()` timestamp at which the edge was observed. */
+  detectedAt: z.number(),
+});
+export type CaptureHealthEventMessage = z.infer<typeof CaptureHealthEventMessageSchema>;
+
+/**
+ * Capture-health broadcast (background → popup). Mirrors
+ * NETWORK_HEALTH_CHANGED. `detectedAt` lets the popup treat each rising edge
+ * as a fresh event for dismissal purposes.
+ */
+export const CaptureHealthChangedMessageSchema = z.object({
+  type: z.literal('CAPTURE_HEALTH_CHANGED'),
+  degraded: z.boolean(),
+  tabId: TabIdSchema.nullable(),
+  detectedAt: z.number().nullable(),
+});
+export type CaptureHealthChangedMessage = z.infer<typeof CaptureHealthChangedMessageSchema>;
+
+/** Popup → background query for current capture-health snapshot. */
+export const GetCaptureHealthMessageSchema = z.object({
+  type: z.literal('GET_CAPTURE_HEALTH'),
+});
+export type GetCaptureHealthMessage = z.infer<typeof GetCaptureHealthMessageSchema>;
+
 export const LatencyUpdateMessageSchema = z.object({
   type: z.literal('LATENCY_UPDATE'),
   streamId: z.string(),

--- a/apps/extension/src/lib/messages.ts
+++ b/apps/extension/src/lib/messages.ts
@@ -135,6 +135,12 @@ export {
   type NetworkEventMessage,
   NetworkHealthChangedMessageSchema,
   type NetworkHealthChangedMessage,
+  CaptureHealthEventMessageSchema,
+  type CaptureHealthEventMessage,
+  CaptureHealthChangedMessageSchema,
+  type CaptureHealthChangedMessage,
+  GetCaptureHealthMessageSchema,
+  type GetCaptureHealthMessage,
   LatencyUpdateMessageSchema,
   type LatencyUpdateMessage,
   LatencyStaleMessageSchema,
@@ -211,6 +217,7 @@ import type {
   WsConnectionLostMessage,
   ConnectionAttemptFailedMessage,
   NetworkHealthChangedMessage,
+  CaptureHealthChangedMessage,
   LatencyUpdateMessage,
   LatencyStaleMessage,
   VideoSyncStateChangedMessage,
@@ -233,6 +240,7 @@ import type {
   WsPermanentlyDisconnectedMessage,
   SonosEventMessage,
   NetworkEventMessage,
+  CaptureHealthEventMessage,
   TopologyEventMessage,
   OffscreenReadyMessage,
   SessionDisconnectedMessage,
@@ -251,6 +259,7 @@ export type PopupToBackgroundType =
   | 'GET_CAST_STATUS'
   | 'GET_SONOS_STATE'
   | 'GET_CONNECTION_STATUS'
+  | 'GET_CAPTURE_HEALTH'
   | 'GET_CURRENT_TAB_STATE'
   | 'GET_ACTIVE_CASTS'
   | 'ENSURE_CONNECTION'
@@ -279,6 +288,7 @@ export type BackgroundToPopupType =
   | 'WS_CONNECTION_LOST'
   | 'CONNECTION_ATTEMPT_FAILED'
   | 'NETWORK_HEALTH_CHANGED'
+  | 'CAPTURE_HEALTH_CHANGED'
   | 'LATENCY_UPDATE'
   | 'LATENCY_STALE';
 
@@ -342,6 +352,7 @@ export type PopupToBackgroundMessage =
   | { type: 'GET_CAST_STATUS' }
   | GetSonosStateMessage
   | { type: 'GET_CONNECTION_STATUS' }
+  | { type: 'GET_CAPTURE_HEALTH' }
   | { type: 'GET_CURRENT_TAB_STATE' }
   | GetActiveCastsMessage
   | EnsureConnectionMessage
@@ -373,6 +384,7 @@ export type BackgroundToPopupMessage =
   | WsConnectionLostMessage
   | ConnectionAttemptFailedMessage
   | NetworkHealthChangedMessage
+  | CaptureHealthChangedMessage
   | LatencyUpdateMessage
   | LatencyStaleMessage
   | VideoSyncStateChangedMessage;
@@ -427,6 +439,7 @@ export type OffscreenToBackgroundMessage =
   | WsPermanentlyDisconnectedMessage
   | SonosEventMessage
   | NetworkEventMessage
+  | CaptureHealthEventMessage
   | TopologyEventMessage
   | OffscreenReadyMessage
   | SessionDisconnectedMessage

--- a/apps/extension/src/locales/en.json
+++ b/apps/extension/src/locales/en.json
@@ -207,7 +207,7 @@
   "sync_speakers_description": "When casting to multiple speakers, group them for perfectly synchronized playback. May temporarily rearrange your Sonos speaker groupings.",
   "capture_mode_browser_enable": "Browser-wide capture",
   "capture_mode_browser_description": "Captures all audio from the browser process. Eliminates frame drops but streams all tabs as one source. Requires the desktop app on Windows 10 21H2+.",
-  "capture_health_frame_drops_message": "Audio stuttering detected. Open settings and enable Browser-wide capture under Advanced for smoother playback.",
+  "capture_health_frame_drops_message": "The audio doesn't seem to be having a good day. Browser-wide capture often sorts that out.",
   "capture_health_action_open_settings": "Open settings",
   "video_sync": "Video Sync",
   "video_sync_toggle": "Sync video to audio",

--- a/apps/extension/src/locales/en.json
+++ b/apps/extension/src/locales/en.json
@@ -207,6 +207,8 @@
   "sync_speakers_description": "When casting to multiple speakers, group them for perfectly synchronized playback. May temporarily rearrange your Sonos speaker groupings.",
   "capture_mode_browser_enable": "Browser-wide capture",
   "capture_mode_browser_description": "Captures all audio from the browser process. Eliminates frame drops but streams all tabs as one source. Requires the desktop app on Windows 10 21H2+.",
+  "capture_health_frame_drops_message": "Audio stuttering detected. Open settings and enable Browser-wide capture under Advanced for smoother playback.",
+  "capture_health_action_open_settings": "Open settings",
   "video_sync": "Video Sync",
   "video_sync_toggle": "Sync video to audio",
   "video_sync_status_waiting": "Waiting",

--- a/apps/extension/src/offscreen/audio-relay.worker.ts
+++ b/apps/extension/src/offscreen/audio-relay.worker.ts
@@ -27,6 +27,7 @@ import {
   BACKPRESSURE_BACKOFF_MAX_MS,
   QUALITY_BACKOFF_MAX_MS,
   FRAME_QUEUE_MAX_BYTES,
+  AUDIO_GAP_THRESHOLD_US,
 } from './worker-base';
 import {
   getStreamingPolicy,
@@ -57,8 +58,10 @@ let accum: Int16Array | null = null;
 let accumOffset = 0;
 let accumView: Uint8Array<ArrayBuffer> | null = null;
 
-// Gaps in AudioData timestamps represent clock reporting jitter, NOT missing
-// audio — the capture device delivers continuous samples.
+// Gaps > AUDIO_GAP_THRESHOLD_US in AudioData timestamps indicate real
+// capture drops from Chrome's LoopbackStream on low-core Windows devices
+// (one AudioData frame = ~9188µs at 48kHz). Sub-threshold deltas are
+// clock-reporting jitter and are ignored.
 let expectedNextTimestamp = -1;
 let loggedFirstFrame = false;
 
@@ -199,7 +202,7 @@ function processAudioData(audioData: AudioData): void {
 
     if (expectedNextTimestamp >= 0 && ts > 0) {
       const gap = ts - expectedNextTimestamp;
-      if (Math.abs(gap) > 100) {
+      if (Math.abs(gap) > AUDIO_GAP_THRESHOLD_US) {
         gapCount++;
         gapDurationUs += Math.abs(gap);
       }
@@ -278,14 +281,13 @@ function getCustomMetrics(): CustomMetrics {
     wakeups: wakeupCount,
     avgSamplesPerWake: wakeupCount > 0 ? totalSamplesRead / wakeupCount : 0,
     encodeQueueSize: 0,
+    gapCount,
+    gapDurationUs,
   };
 }
 
-/** Resets per-interval counters after stats are posted; logs a debug line if timestamp gaps occurred. */
+/** Resets per-interval counters after stats are posted. */
 function resetCustomCounters(): void {
-  if (gapCount > 0) {
-    s.log.debug(`AudioData gaps: ${gapCount} gaps, ${(gapDurationUs / 1000).toFixed(1)}ms total`);
-  }
   wakeupCount = 0;
   totalSamplesRead = 0;
   droppedFrameCount = 0;

--- a/apps/extension/src/offscreen/handlers.ts
+++ b/apps/extension/src/offscreen/handlers.ts
@@ -208,6 +208,14 @@ export function setupMessageHandlers(): void {
         if (existing) {
           existing.stop();
           activeSessions.delete(tabId);
+          chrome.runtime
+            .sendMessage({
+              type: 'CAPTURE_HEALTH_EVENT',
+              tabId,
+              degraded: false,
+              detectedAt: Date.now(),
+            })
+            .catch(noop);
         }
 
         // Enforce global offscreen limit
@@ -270,6 +278,14 @@ export function setupMessageHandlers(): void {
           log.info(`Stopping existing session for tab ${tabId} before restart`);
           existing.stop();
           activeSessions.delete(tabId);
+          chrome.runtime
+            .sendMessage({
+              type: 'CAPTURE_HEALTH_EVENT',
+              tabId,
+              degraded: false,
+              detectedAt: Date.now(),
+            })
+            .catch(noop);
         }
 
         // Enforce global offscreen limit
@@ -299,6 +315,17 @@ export function setupMessageHandlers(): void {
               chrome.runtime.sendMessage({ type: 'SESSION_DISCONNECTED', tabId }).catch(noop);
             };
 
+            const onHealthChanged = (health: { degraded: boolean; detectedAt: number }) => {
+              chrome.runtime
+                .sendMessage({
+                  type: 'CAPTURE_HEALTH_EVENT',
+                  tabId,
+                  degraded: health.degraded,
+                  detectedAt: health.detectedAt,
+                })
+                .catch(noop);
+            };
+
             const session = StreamSession.forTabCapture(
               stream,
               encoderConfig,
@@ -306,6 +333,7 @@ export function setupMessageHandlers(): void {
               onDisconnected,
               {
                 keepTabAudible,
+                onHealthChanged,
               },
             );
             try {

--- a/apps/extension/src/offscreen/stream-session.ts
+++ b/apps/extension/src/offscreen/stream-session.ts
@@ -842,8 +842,10 @@ export class StreamSession {
   }
 
   /**
-   * Fires `onHealthChanged` on two consecutive above-threshold windows (rising)
-   * or a single below-threshold window (falling). Tab-capture + PCM only.
+   * Fires `onHealthChanged` on two consecutive above-threshold windows (rising
+   * edge only). Internal state still flips on recovery so a future rising edge
+   * can re-fire, but alerts are sticky on the popup side and don't auto-clear.
+   * Tab-capture + PCM only.
    * @param gapsThisTick - gap count reported in the latest STATS message
    */
   private evaluateCaptureHealth(gapsThisTick: number): void {
@@ -862,11 +864,10 @@ export class StreamSession {
     const aboveThreshold = windowSum >= GAP_THRESHOLD;
 
     if (this.isDegraded) {
-      // Falling edge: degraded → healthy once the window clears.
-      if (!aboveThreshold) {
-        this.isDegraded = false;
-        this.onHealthChanged?.({ degraded: false, detectedAt: Date.now() });
-      }
+      // Recovery: flip internal state silently so the next rising edge can
+      // fire again. We don't broadcast — alerts are sticky and only clear on
+      // user dismissal or session end.
+      if (!aboveThreshold) this.isDegraded = false;
       return;
     }
 

--- a/apps/extension/src/offscreen/stream-session.ts
+++ b/apps/extension/src/offscreen/stream-session.ts
@@ -48,6 +48,11 @@ const HEALTHY_STATS_LOG_INTERVAL = 30000;
 /** Minimum gain value to keep Chrome's audio detection active without audible sound. */
 const KEEP_AUDIBLE_GAIN = 0.0001;
 
+/** Capture-health detector: ring size in STATS ticks (3 × 2s = 6s window). */
+const GAP_WINDOW_TICKS = 3;
+/** Capture-health detector: drops-in-window threshold for sustained loss. */
+const GAP_THRESHOLD = 3;
+
 /**
  * Manages an active capture session.
  *
@@ -133,6 +138,18 @@ export class StreamSession {
   private totalConsumerDrops = 0;
   private totalUnderflows = 0;
   private totalFrameQueueDrops = 0;
+  // Capture-health detector (tab+PCM only — LoopbackStream frame-drop signal).
+  /** Ring of per-interval gap counts (one entry per STATS tick). */
+  private gapHistory: number[] = [];
+  /** Current degradation state (edge-triggered; only fires on transitions). */
+  private isDegraded = false;
+  /**
+   * Set when an above-threshold window is seen; requires a second consecutive
+   * above-threshold window to confirm and fire. One-tick debounce — suppresses
+   * a spike that lands on the first full window (warm-up) and shifts out on
+   * the next evaluation before anything else above-threshold arrives.
+   */
+  private pendingDegraded = false;
 
   /** Last time we logged diagnostics (for rate-limiting when healthy). */
   private lastDiagLogTime = 0;
@@ -142,6 +159,9 @@ export class StreamSession {
 
   /** Callback when server reports a capture error (browser capture mode only). */
   private onError?: (error: string, reason?: string) => void;
+
+  /** Tab-capture + PCM only — no signal on other codec paths. */
+  private onHealthChanged?: (health: { degraded: boolean; detectedAt: number }) => void;
 
   /** Whether to play audio at low volume to prevent Chrome throttling. */
   private keepTabAudible: boolean;
@@ -169,6 +189,7 @@ export class StreamSession {
    * @param onDisconnected - Optional callback when worker WebSocket disconnects
    * @param options - Additional session options
    * @param options.keepTabAudible - Play audio at low volume to prevent Chrome throttling
+   * @param options.onHealthChanged - Capture-health transition callback (tab+PCM only)
    * @returns A new StreamSession configured for tab audio capture
    */
   static forTabCapture(
@@ -176,7 +197,10 @@ export class StreamSession {
     encoderConfig: EncoderConfig,
     baseUrl: string,
     onDisconnected?: () => void,
-    options?: { keepTabAudible?: boolean },
+    options?: {
+      keepTabAudible?: boolean;
+      onHealthChanged?: (health: { degraded: boolean; detectedAt: number }) => void;
+    },
   ): StreamSession {
     return new StreamSession({
       captureMode: 'tab',
@@ -185,6 +209,7 @@ export class StreamSession {
       baseUrl,
       onDisconnected,
       keepTabAudible: options?.keepTabAudible,
+      onHealthChanged: options?.onHealthChanged,
     });
   }
 
@@ -226,6 +251,7 @@ export class StreamSession {
    * @param config.baseUrl - Desktop app base URL
    * @param config.onDisconnected - Optional callback when worker WebSocket disconnects
    * @param config.onError - Optional callback when server reports a capture error
+   * @param config.onHealthChanged - Capture-health transition callback (tab capture + PCM only)
    * @param config.keepTabAudible - Play audio at low volume to prevent Chrome throttling (tab capture only)
    * @param config.browserName - Browser executable name for PID lookup (browser capture only)
    */
@@ -236,6 +262,7 @@ export class StreamSession {
     baseUrl: string;
     onDisconnected?: () => void;
     onError?: (error: string, reason?: string) => void;
+    onHealthChanged?: (health: { degraded: boolean; detectedAt: number }) => void;
     keepTabAudible?: boolean;
     browserName?: string;
   }) {
@@ -245,6 +272,7 @@ export class StreamSession {
     this.baseUrl = config.baseUrl;
     this.onDisconnected = config.onDisconnected;
     this.onError = config.onError;
+    this.onHealthChanged = config.onHealthChanged;
     this.keepTabAudible = config.keepTabAudible ?? false;
     this.browserName = config.browserName;
 
@@ -661,6 +689,8 @@ export class StreamSession {
           this.totalUnderflows += msg.underflows ?? 0;
           this.totalFrameQueueDrops += msg.frameQueueOverflowDrops ?? 0;
 
+          this.evaluateCaptureHealth(msg.gapCount ?? 0);
+
           if (msg.producerDroppedSamples > 0) {
             log.warn(
               `Audio ring buffer overflow (${msg.producerDroppedSamples} samples)! Encoder or network too slow.`,
@@ -686,12 +716,14 @@ export class StreamSession {
           }
 
           // Rate-limit diagnostic logs: log immediately on issues, otherwise every 30s
+          const gapCount = msg.gapCount ?? 0;
           const hasIssues =
             msg.underflows > 0 ||
             msg.producerDroppedSamples > 0 ||
             msg.catchUpDroppedSamples > 0 ||
             msg.consumerDroppedFrames > 0 ||
-            msg.frameQueueOverflowDrops > 0;
+            msg.frameQueueOverflowDrops > 0 ||
+            gapCount > 0;
           const now = performance.now();
           const timeSinceLastLog = now - this.lastDiagLogTime;
 
@@ -702,7 +734,7 @@ export class StreamSession {
                 `frameQueue=${msg.frameQueueSize ?? 0}/${((msg.frameQueueBytes ?? 0) / 1024).toFixed(0)}KB ` +
                 `underflows=${msg.underflows} producerDrops=${msg.producerDroppedSamples} ` +
                 `catchUpDrops=${msg.catchUpDroppedSamples} consumerDrops=${msg.consumerDroppedFrames} ` +
-                `frameQueueDrops=${msg.frameQueueOverflowDrops ?? 0}`,
+                `frameQueueDrops=${msg.frameQueueOverflowDrops ?? 0} gaps=${gapCount}`,
             );
             this.lastDiagLogTime = now;
           }
@@ -766,6 +798,11 @@ export class StreamSession {
   public stop(): void {
     this.stopHeartbeatChecker();
 
+    // Unwire the health callback before deferring terminate — a late STATS
+    // tick in the 500ms window could otherwise fire a rising-edge event for
+    // a session we're already replacing.
+    this.onHealthChanged = undefined;
+
     if (this.consumerWorker) {
       this.consumerWorker.postMessage({ type: 'STOP' });
       // Defer terminate to allow worker to post METRICS_DUMP back
@@ -801,6 +838,50 @@ export class StreamSession {
       }
 
       this.mediaStream.getTracks().forEach((t) => t.stop());
+    }
+  }
+
+  /**
+   * Fires `onHealthChanged` on two consecutive above-threshold windows (rising)
+   * or a single below-threshold window (falling). Tab-capture + PCM only.
+   * @param gapsThisTick - gap count reported in the latest STATS message
+   */
+  private evaluateCaptureHealth(gapsThisTick: number): void {
+    if (this.captureMode !== 'tab' || this.encoderConfig.codec !== 'pcm') return;
+
+    this.gapHistory.push(gapsThisTick);
+    if (this.gapHistory.length > GAP_WINDOW_TICKS) {
+      this.gapHistory.shift();
+    }
+
+    // Wait until the window is full before evaluating — avoids firing on a
+    // single noisy tick at session start.
+    if (this.gapHistory.length < GAP_WINDOW_TICKS) return;
+
+    const windowSum = this.gapHistory.reduce((a, b) => a + b, 0);
+    const aboveThreshold = windowSum >= GAP_THRESHOLD;
+
+    if (this.isDegraded) {
+      // Falling edge: degraded → healthy once the window clears.
+      if (!aboveThreshold) {
+        this.isDegraded = false;
+        this.onHealthChanged?.({ degraded: false, detectedAt: Date.now() });
+      }
+      return;
+    }
+
+    // Confirmation delay: require two consecutive above-threshold windows
+    // before announcing degradation, so single system hitches don't fire.
+    if (aboveThreshold) {
+      if (this.pendingDegraded) {
+        this.isDegraded = true;
+        this.pendingDegraded = false;
+        this.onHealthChanged?.({ degraded: true, detectedAt: Date.now() });
+      } else {
+        this.pendingDegraded = true;
+      }
+    } else {
+      this.pendingDegraded = false;
     }
   }
 

--- a/apps/extension/src/offscreen/worker-base.ts
+++ b/apps/extension/src/offscreen/worker-base.ts
@@ -39,6 +39,14 @@ export const WAIT_TIMEOUT_MS = 200;
 /** Interval for posting diagnostic stats to main thread (ms). */
 export const STATS_INTERVAL_MS = 2000;
 
+/**
+ * Minimum AudioData-timestamp gap (µs) that counts as a real capture drop.
+ * Chrome's LoopbackStream drops whole AudioData frames (~9188µs at 48kHz) on
+ * low-core Windows devices; healthy hardware emits only sub-ms jitter, so
+ * 5000µs (≈ half a frame) is a comfortable discriminator.
+ */
+export const AUDIO_GAP_THRESHOLD_US = 5000;
+
 /** Heartbeat interval for WebSocket (ms). */
 export const HEARTBEAT_INTERVAL_MS = 5000;
 
@@ -85,6 +93,10 @@ export interface CustomMetrics {
   avgSamplesPerWake: number;
   /** Current encoder queue depth. */
   encodeQueueSize: number;
+  /** AudioData timestamp gaps exceeding AUDIO_GAP_THRESHOLD_US (MSTP path only). */
+  gapCount?: number;
+  /** Total gap duration (µs) for this interval (MSTP path only). */
+  gapDurationUs?: number;
 }
 
 /**
@@ -430,6 +442,8 @@ export function maybePostStats(
     frameQueueSize: s.frameQueue.length,
     frameQueueBytes: s.frameQueueBytes,
     frameQueueOverflowDrops: s.frameQueueOverflowDrops,
+    gapCount: custom.gapCount ?? 0,
+    gapDurationUs: custom.gapDurationUs ?? 0,
   });
 
   // Reset shared interval counters

--- a/apps/extension/src/offscreen/worker-messages.ts
+++ b/apps/extension/src/offscreen/worker-messages.ts
@@ -169,6 +169,10 @@ export interface WorkerStatsMessage {
   frameQueueBytes: number;
   /** Frames dropped due to queue overflow. */
   frameQueueOverflowDrops: number;
+  /** AudioData timestamp gaps this interval (MSTP path only, undefined elsewhere). */
+  gapCount?: number;
+  /** Total gap duration (µs) this interval (MSTP path only, undefined elsewhere). */
+  gapDurationUs?: number;
 }
 
 /** A single metrics snapshot captured during streaming. */

--- a/apps/extension/src/popup/App.tsx
+++ b/apps/extension/src/popup/App.tsx
@@ -25,6 +25,7 @@ import { useOnboarding } from './hooks/useOnboarding';
 import { useExtensionSettingsListener } from './hooks/useExtensionSettingsListener';
 import { useSpeakerSelection } from './hooks/useSpeakerSelection';
 import { useCompanionVersion } from './hooks/useCompanionVersion';
+import { useCaptureHealth } from './hooks/useCaptureHealth';
 import { companionTypeLabelKey, versionMismatchActionKey } from '../lib/versionCheck';
 import { Onboarding } from './components/Onboarding';
 
@@ -124,6 +125,10 @@ function MainPopup(): JSX.Element {
   // Companion version mismatch warning
   const { companion, hasMismatch, showMismatchWarning, dismissMismatchWarning } =
     useCompanionVersion(connection);
+
+  // Capture-health alert (LoopbackStream frame drops on low-core Windows)
+  const { showAlert: showCaptureHealthAlert, dismiss: dismissCaptureHealthAlert } =
+    useCaptureHealth();
 
   const handleOpenReleases = useCallback(() => {
     chrome.tabs.create({ url: GITHUB_RELEASES_URL });
@@ -321,6 +326,18 @@ function MainPopup(): JSX.Element {
           {t(`network.${networkHealthReason}`, {
             defaultValue: t('network.speakers_not_responding'),
           })}
+        </Alert>
+      )}
+
+      {wsConnected && showCaptureHealthAlert && (
+        <Alert
+          variant="warning"
+          className={styles.alert}
+          action={t('capture_health_action_open_settings')}
+          onAction={openSettings}
+          onDismiss={dismissCaptureHealthAlert}
+        >
+          {t('capture_health_frame_drops_message')}
         </Alert>
       )}
 

--- a/apps/extension/src/popup/hooks/useCaptureHealth.ts
+++ b/apps/extension/src/popup/hooks/useCaptureHealth.ts
@@ -5,10 +5,14 @@
  * the cached snapshot from the background on mount and updates on every
  * `CAPTURE_HEALTH_CHANGED` broadcast.
  *
- * Dismissal is keyed on `detectedAt` and persisted in `chrome.storage.local`
- * so popup close/reopen during a sustained degraded session doesn't
- * resurrect the dismissed alert. Each rising edge carries a new `detectedAt`,
- * so re-arming on a fresh event is automatic.
+ * Alerts are sticky: once shown, they only clear on user dismissal or when
+ * the cast session ends (background broadcasts a cleared state). Recoveries
+ * within a session don't auto-hide.
+ *
+ * Dismissal is keyed on `detectedAt` and persisted in `chrome.storage.local`,
+ * so popup close/reopen during an un-dismissed alert keeps the alert visible.
+ * Each rising edge carries a new `detectedAt`, so a fresh detection after
+ * dismissal naturally re-arms.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
@@ -90,8 +94,11 @@ export function useCaptureHealth(): UseCaptureHealthResult {
   }, [health.detectedAt]);
 
   // Suppress until dismissedAt has loaded, otherwise a previously-dismissed
-  // event would flash the alert on every popup open.
-  const showAlert = dismissedLoaded && health.degraded && health.detectedAt !== dismissedAt;
+  // event would flash the alert on every popup open. Alert is decoupled from
+  // `health.degraded` — sticky behavior means we show whenever there's an
+  // un-dismissed detection event, regardless of current degraded status.
+  const showAlert =
+    dismissedLoaded && health.detectedAt !== null && health.detectedAt !== dismissedAt;
 
   return { showAlert, dismiss };
 }

--- a/apps/extension/src/popup/hooks/useCaptureHealth.ts
+++ b/apps/extension/src/popup/hooks/useCaptureHealth.ts
@@ -1,0 +1,97 @@
+/**
+ * Capture-health hook.
+ *
+ * Mirrors the `useConnectionStatus` → `NETWORK_HEALTH_CHANGED` wiring. Reads
+ * the cached snapshot from the background on mount and updates on every
+ * `CAPTURE_HEALTH_CHANGED` broadcast.
+ *
+ * Dismissal is keyed on `detectedAt` and persisted in `chrome.storage.local`
+ * so popup close/reopen during a sustained degraded session doesn't
+ * resurrect the dismissed alert. Each rising edge carries a new `detectedAt`,
+ * so re-arming on a fresh event is automatic.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import type { CaptureHealthState } from '../../background/capture-health-state';
+import { useChromeMessage } from './useChromeMessage';
+import { useMountedRef } from './useMountedRef';
+
+export interface UseCaptureHealthResult {
+  /** Whether the popup should currently render the Alert. */
+  showAlert: boolean;
+  /** Dismisses the current detection event — cleared automatically on a fresh edge. */
+  dismiss: () => void;
+}
+
+const DISMISSED_AT_STORAGE_KEY = 'dismissedCaptureHealthAt';
+
+/**
+ * Tracks capture-health state and exposes a dismissible alert signal.
+ * @returns Alert visibility flag and dismiss callback
+ */
+export function useCaptureHealth(): UseCaptureHealthResult {
+  const [health, setHealth] = useState<CaptureHealthState>({
+    degraded: false,
+    tabId: null,
+    detectedAt: null,
+  });
+  const [dismissedAt, setDismissedAt] = useState<number | null>(null);
+  const [dismissedLoaded, setDismissedLoaded] = useState(false);
+  const mountedRef = useMountedRef();
+  // If a broadcast lands before the initial GET resolves, the stale GET
+  // response must not overwrite the newer broadcast state.
+  const broadcastReceivedRef = useRef(false);
+
+  useEffect(() => {
+    chrome.runtime
+      .sendMessage({ type: 'GET_CAPTURE_HEALTH' })
+      .then((snapshot: CaptureHealthState | undefined) => {
+        if (!mountedRef.current || !snapshot) return;
+        if (broadcastReceivedRef.current) return;
+        setHealth(snapshot);
+      })
+      .catch(() => {
+        /* background not ready yet — broadcast will fill in when it arrives */
+      });
+
+    chrome.storage.local
+      .get(DISMISSED_AT_STORAGE_KEY)
+      .then((result) => {
+        if (!mountedRef.current) return;
+        const stored = result[DISMISSED_AT_STORAGE_KEY];
+        setDismissedAt(typeof stored === 'number' ? stored : null);
+      })
+      .catch(() => {
+        /* storage unavailable — treat as no dismissal */
+      })
+      .finally(() => {
+        if (mountedRef.current) setDismissedLoaded(true);
+      });
+  }, []);
+
+  useChromeMessage((message) => {
+    const msg = message as { type: string; [key: string]: unknown };
+    if (msg.type !== 'CAPTURE_HEALTH_CHANGED') return;
+    broadcastReceivedRef.current = true;
+    setHealth({
+      degraded: msg.degraded as boolean,
+      tabId: (msg.tabId as number | null) ?? null,
+      detectedAt: (msg.detectedAt as number | null) ?? null,
+    });
+  });
+
+  const dismiss = useCallback(() => {
+    const at = health.detectedAt;
+    if (at === null) return;
+    setDismissedAt(at);
+    chrome.storage.local.set({ [DISMISSED_AT_STORAGE_KEY]: at }).catch(() => {
+      /* best-effort; in-memory state still hides the alert this session */
+    });
+  }, [health.detectedAt]);
+
+  // Suppress until dismissedAt has loaded, otherwise a previously-dismissed
+  // event would flash the alert on every popup open.
+  const showAlert = dismissedLoaded && health.degraded && health.detectedAt !== dismissedAt;
+
+  return { showAlert, dismiss };
+}


### PR DESCRIPTION
## What

Adds an edge-triggered capture-health detector to `StreamSession` that watches `AudioData` timestamp gaps. When three or more real drops land inside a rolling six-second window and the condition persists across two consecutive evaluations, the popup renders a dismissible alert pointing the user at Advanced settings to enable Browser-wide capture (which bypasses Chrome's LoopbackStream entirely).

Signal path: `audio-relay.worker.ts` → `CustomMetrics.gapCount` → `StreamSession.evaluateCaptureHealth` → `CAPTURE_HEALTH_EVENT` (offscreen → background) → `capture-health-state.ts` → `CAPTURE_HEALTH_CHANGED` (background → popup) → `useCaptureHealth` hook → `Alert` in `App.tsx`.

Dismissal is keyed on `detectedAt` and persisted in `chrome.storage.local` so popup close/reopen during a sustained degraded session doesn't resurrect the dismissed alert. Each rising edge carries a fresh `detectedAt`, so re-arming on a new detection event is automatic.

## Why

On low-core Windows devices (e.g. Surface Go, 2-core Pentium Gold) Chrome's tab-capture LoopbackStream drops whole `AudioData` frames at ~2/sec — each drop is one frame (~9 ms at 48 kHz). Audio plays to the speakers correctly; only the captured stream is affected, which manifests as audible stuttering on the cast side.

The project already ships a WASAPI-based "Browser-wide capture" setting that bypasses LoopbackStream, but it's buried in Advanced and undiscoverable. Users can't self-diagnose. This PR surfaces the problem and the remediation.

## How to Test

- Cast from a tab using the default (PCM) codec.
- On healthy hardware (4+ cores, idle): no alert should appear.
- On affected hardware, or by artificially injecting drops into `audio-relay.worker.ts`: within ~8 s the popup renders "Audio stuttering detected. Open settings and enable Browser-wide capture under Advanced for smoother playback." with an "Open settings" action.
- Click the action → Options page opens; enabling Browser-wide capture + restarting the cast suppresses the alert (detector is gated on tab-capture + PCM).
- Dismissal: click dismiss → alert hides. Close the popup, reopen while still degraded → alert stays hidden (dismissal persisted per-`detectedAt`). Let the session recover (no drops for 6 s) and re-degrade → alert reappears with a new `detectedAt`.
- Multi-tab: degrade Tab A, briefly degrade + recover Tab B → Tab A's alert should not be cleared by Tab B's falling edge.
- Session replacement: start a PCM cast on tab, then restart the cast (either same mode or switch to Browser capture) → any lingering "degraded" state clears immediately.

## Related Issue

None.

---

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)